### PR TITLE
feat: SessionStore にファイル永続化を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,11 @@ AUTHORIZED_USER_ID=
 # ツール許可や MCP 設定はワークスペースの
 # .claude/settings.json, .mcp.json で管理する
 
+# ===== セッション =====
+# セッション永続化ファイルのパス（デフォルト: ./data/sessions.json）
+# チャンネル ID と Claude セッション ID の紐付けを保存し、再起動後も --resume で会話を継続する
+# SESSION_FILE=./data/sessions.json
+
 # ===== ログ =====
 # ログレベル: DEBUG / INFO / WARN / ERROR（デフォルト: INFO）
 LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 coverage/
+data/
 docker/claude-home/*
 docker/claude-workspace/*
 !**/.gitkeep

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ bot/commands.ts        スラッシュコマンド定義（/claw clear）。
 bot/guard.ts           isAuthorized(): ギルド ID + ユーザー ID + bot 除外の認可チェック。
 bot/message.ts         splitMessage(): 2000 文字分割。keepTyping(): typing インジケーター維持。ProgressReporter: ツール進捗表示。
 claude/mod.ts          askClaude(): Deno.Command で claude -p を spawn し stream-json 出力を逐次パース。
-session/mod.ts         SessionStore: チャンネル/スレッド ID → session_id の Map。
+session/mod.ts         SessionStore: チャンネル/スレッド ID → session_id のマッピング。JSON ファイルへの永続化対応。
 approval/manager.ts    ApprovalManager: Discord ボタンによるツール承認/拒否。
 approval/server.ts     承認 HTTP サーバー。PreToolUse フックのエンドポイント。
 approval/types.ts      HookInput, ApprovalResult の型定義。
@@ -165,9 +165,7 @@ Deno.test("isAuthorized", async (t) => {
 
 ### 機能
 
-- [x] `--output-format stream-json` 対応: リアルタイム進捗表示（typing 中に「ツール実行中...」等を表示）
 - [ ] VC（ボイスチャンネル）対応: discord-vc の STT/TTS パイプラインを統合
-- [ ] セッション永続化: プロセス再起動時のセッション復元（現在はインメモリ Map で再起動で消える）
 - [ ] `--model` 指定: Discord コマンドでモデル切り替え（opus/sonnet/haiku）
 - [ ] スレッド自動作成: active channel でのメッセージをスレッドに分離
 

--- a/bot/guard.test.ts
+++ b/bot/guard.test.ts
@@ -14,6 +14,7 @@ const baseConfig: Config = {
     cwd: "/tmp",
     approvalPort: 3000,
   },
+  sessionFile: "./data/sessions.json",
 };
 
 Deno.test("isAuthorized", async (t) => {

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -34,12 +34,13 @@ const log = createLogger("bot");
 export class DiscordBot {
   private client: Client;
   private config: Config;
-  private sessions = new SessionStore();
+  private sessions: SessionStore;
   private approvalManager: ApprovalManager;
   private approvalServer: Deno.HttpServer | null = null;
 
   constructor(config: Config) {
     this.config = config;
+    this.sessions = new SessionStore(config.sessionFile);
     this.client = new Client({
       intents: [
         GatewayIntentBits.Guilds,

--- a/config.test.ts
+++ b/config.test.ts
@@ -88,6 +88,21 @@ Deno.test("loadConfig", async (t) => {
     });
   });
 
+  await t.step("sessionFile のデフォルト値が適用されること", () => {
+    withEnv(requiredEnv, () => {
+      Deno.env.delete("SESSION_FILE");
+      const config = loadConfig();
+      assertEquals(config.sessionFile, "./data/sessions.json");
+    });
+  });
+
+  await t.step("SESSION_FILE を環境変数で上書きできること", () => {
+    withEnv({ ...requiredEnv, SESSION_FILE: "/tmp/sessions.json" }, () => {
+      const config = loadConfig();
+      assertEquals(config.sessionFile, "/tmp/sessions.json");
+    });
+  });
+
   await t.step("claude 設定を環境変数で上書きできること", () => {
     withEnv(
       {

--- a/config.ts
+++ b/config.ts
@@ -35,6 +35,8 @@ export interface Config {
   activeChannelIds: string[];
   /** Claude Code CLI 設定。 */
   claude: ClaudeConfig;
+  /** セッション永続化ファイルのパス。 */
+  sessionFile: string;
 }
 
 /**
@@ -75,5 +77,6 @@ export function loadConfig(): Config {
       cwd: Deno.cwd(),
       approvalPort: Number(Deno.env.get("APPROVAL_PORT") ?? "3000"),
     },
+    sessionFile: Deno.env.get("SESSION_FILE") ?? "./data/sessions.json",
   };
 }

--- a/session/mod.test.ts
+++ b/session/mod.test.ts
@@ -1,7 +1,8 @@
 import { assertEquals } from "@std/assert";
+import { join } from "node:path";
 import { SessionStore } from "./mod.ts";
 
-Deno.test("SessionStore", async (t) => {
+Deno.test("SessionStore (インメモリ)", async (t) => {
   await t.step("未登録のキーは undefined を返すこと", () => {
     const store = new SessionStore();
     assertEquals(store.get("ch-1"), undefined);
@@ -39,5 +40,108 @@ Deno.test("SessionStore", async (t) => {
     store.clear();
     assertEquals(store.get("ch-1"), undefined);
     assertEquals(store.get("ch-2"), undefined);
+  });
+});
+
+Deno.test("SessionStore (ファイル永続化)", async (t) => {
+  await t.step("ファイル未存在で起動できること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      const store = new SessionStore(path);
+      assertEquals(store.get("ch-1"), undefined);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("set でファイルに書き込まれること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      const store = new SessionStore(path);
+      store.set("ch-1", "session-a");
+
+      const data = JSON.parse(Deno.readTextFileSync(path));
+      assertEquals(data, { "ch-1": "session-a" });
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("ファイルからセッションを復元できること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      Deno.writeTextFileSync(
+        path,
+        JSON.stringify({ "ch-1": "session-a", "ch-2": "session-b" }),
+      );
+
+      const store = new SessionStore(path);
+      assertEquals(store.get("ch-1"), "session-a");
+      assertEquals(store.get("ch-2"), "session-b");
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("delete でファイルが更新されること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      const store = new SessionStore(path);
+      store.set("ch-1", "session-a");
+      store.set("ch-2", "session-b");
+      store.delete("ch-1");
+
+      const data = JSON.parse(Deno.readTextFileSync(path));
+      assertEquals(data, { "ch-2": "session-b" });
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("clear でファイルが空オブジェクトになること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      const store = new SessionStore(path);
+      store.set("ch-1", "session-a");
+      store.set("ch-2", "session-b");
+      store.clear();
+
+      const data = JSON.parse(Deno.readTextFileSync(path));
+      assertEquals(data, {});
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("不正な JSON でもエラーにならず起動すること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "sessions.json");
+      Deno.writeTextFileSync(path, "{broken json!!!");
+
+      const store = new SessionStore(path);
+      assertEquals(store.get("ch-1"), undefined);
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
+  });
+
+  await t.step("親ディレクトリが自動作成されること", async () => {
+    const dir = await Deno.makeTempDir();
+    try {
+      const path = join(dir, "nested", "deep", "sessions.json");
+      const store = new SessionStore(path);
+      store.set("ch-1", "session-a");
+
+      const data = JSON.parse(Deno.readTextFileSync(path));
+      assertEquals(data, { "ch-1": "session-a" });
+    } finally {
+      await Deno.remove(dir, { recursive: true });
+    }
   });
 });

--- a/session/mod.ts
+++ b/session/mod.ts
@@ -3,14 +3,30 @@
  *
  * Discord のチャンネル ID をキーに、Claude Code の session_id を保持する。
  * `--resume` フラグで会話を継続する際に使う。
- * インメモリ実装のため、プロセス再起動でセッションは消える。
+ *
+ * コンストラクタに `filePath` を渡すと JSON ファイルに永続化し、
+ * プロセス再起動後もセッションを復元できる。
+ * 省略した場合はインメモリのみで動作する。
  */
+
+import { dirname } from "node:path";
+import { createLogger } from "../logger.ts";
+
+const log = createLogger("session");
 
 /**
  * セッションストア。
  */
 export class SessionStore {
   private sessions = new Map<string, string>();
+  private filePath: string | undefined;
+
+  constructor(filePath?: string) {
+    this.filePath = filePath;
+    if (filePath) {
+      this.loadSync();
+    }
+  }
 
   /** チャンネル/スレッド ID からセッション ID を取得する。 */
   get(channelId: string): string | undefined {
@@ -20,15 +36,62 @@ export class SessionStore {
   /** チャンネル/スレッド ID にセッション ID を紐づける。 */
   set(channelId: string, sessionId: string): void {
     this.sessions.set(channelId, sessionId);
+    this.persist();
   }
 
   /** チャンネル/スレッド ID のセッションを削除する。 */
   delete(channelId: string): boolean {
-    return this.sessions.delete(channelId);
+    const result = this.sessions.delete(channelId);
+    this.persist();
+    return result;
   }
 
   /** 全セッションを削除する。 */
   clear(): void {
     this.sessions.clear();
+    this.persist();
+  }
+
+  /** ファイルからセッションを復元する。 */
+  private loadSync(): void {
+    try {
+      const text = Deno.readTextFileSync(this.filePath!);
+      const data: unknown = JSON.parse(text);
+      if (data !== null && typeof data === "object" && !Array.isArray(data)) {
+        for (
+          const [key, value] of Object.entries(data as Record<string, unknown>)
+        ) {
+          if (typeof value === "string") {
+            this.sessions.set(key, value);
+          }
+        }
+      }
+      log.info(`loaded ${this.sessions.size} session(s) from ${this.filePath}`);
+    } catch (error: unknown) {
+      if (error instanceof Deno.errors.NotFound) {
+        log.info(`session file not found, starting empty: ${this.filePath}`);
+        return;
+      }
+      log.warn(`failed to load session file, starting empty: ${error}`);
+    }
+  }
+
+  /** セッションをファイルに書き込む。 */
+  private persist(): void {
+    if (!this.filePath) {
+      return;
+    }
+    try {
+      const dir = dirname(this.filePath);
+      Deno.mkdirSync(dir, { recursive: true });
+      const json = JSON.stringify(
+        Object.fromEntries(this.sessions),
+        null,
+        2,
+      );
+      Deno.writeTextFileSync(this.filePath, json + "\n");
+    } catch (error: unknown) {
+      log.error(`failed to persist sessions: ${error}`);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- `SessionStore` に `filePath` コンストラクタ引数を追加し、JSON ファイルへの永続化に対応
- `set` / `delete` / `clear` 時に即時書き込み、起動時にファイルから復元
- `SESSION_FILE` 環境変数でパス指定可能（デフォルト: `./data/sessions.json`）

Closes #4

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `session/mod.ts` | `filePath` 引数追加、`loadSync()` / `persist()` 実装 |
| `session/mod.test.ts` | ファイル永続化テスト 7 件追加 |
| `config.ts` | `sessionFile` フィールド追加 |
| `config.test.ts` | `sessionFile` テスト 2 件追加 |
| `bot/mod.ts` | `new SessionStore(config.sessionFile)` に変更 |
| `bot/guard.test.ts` | テストデータに `sessionFile` 追加 |
| `.env.example` | `SESSION_FILE` の説明追加 |
| `.gitignore` | `data/` 追加 |
| `CLAUDE.md` | 課題リスト更新、ファイル構成説明更新 |

## Test plan

- [x] `deno task test` — 全 69 ステップ通過
- [x] `deno task check` — 型チェック通過
- [x] `deno task lint` — lint + format 通過
- [ ] Docker 環境での動作確認（`/workspace/data/sessions.json` に永続化されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)