### PR TITLE
feat: Docker コンテナのタイムゾーンを環境変数で設定可能にする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,9 @@ AUTHORIZED_USER_ID=
 LOG_LEVEL=INFO
 
 # ===== Docker 専用（compose.yaml から参照） =====
+# コンテナのタイムゾーン（IANA 形式、デフォルト: UTC）
+# 例: Asia/Tokyo, America/New_York
+# TZ=Asia/Tokyo
 # ワークスペースのホスト側パス（未設定: docker/claude-workspace）
 # .claude/, CLAUDE.md, .mcp.json 等がここに存在する
 # CLAUDE_WORKSPACE=./claude-workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/denoland/deno:debian-2.7.8
 
 RUN <<EOF
 apt-get update
-apt-get install -y --no-install-recommends ca-certificates curl git bubblewrap socat ffmpeg
+apt-get install -y --no-install-recommends ca-certificates curl git bubblewrap socat ffmpeg tzdata
 rm -rf /var/lib/apt/lists/*
 EOF
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -5,6 +5,8 @@ services:
     build: ..
     env_file:
       - ../.env
+    environment:
+      - TZ=${TZ:-UTC}
     working_dir: /workspace
     command: ["deno", "run", "-A", "/app/main.ts"]
     volumes:


### PR DESCRIPTION
## Summary

- Dockerfile に `tzdata` パッケージを追加
- `compose.yaml` で `TZ` 環境変数をコンテナに渡す（デフォルト: UTC）
- `.env.example` に `TZ` の説明を追加

Closes #10

## Test plan

- [ ] `TZ=Asia/Tokyo` を `.env` に設定して `docker compose up` し、コンテナ内で `date` が JST を返すことを確認
- [ ] `TZ` 未設定で UTC になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)