### PR TITLE
feat: テキストチャットの画像添付を Claude に渡す

### DIFF
--- a/bot/message.test.ts
+++ b/bot/message.test.ts
@@ -232,7 +232,7 @@ Deno.test("resizeImageIfNeeded", async (t) => {
     const [result, ext] = await resizeImageIfNeeded(buf, 1568);
     assertEquals(ext, ".jpg");
 
-    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    const resized = await Jimp.fromBuffer(new Uint8Array(result).buffer);
     assertEquals(resized.width, 1568);
     assertEquals(resized.height <= 1568, true);
   });
@@ -242,7 +242,7 @@ Deno.test("resizeImageIfNeeded", async (t) => {
     const [result, ext] = await resizeImageIfNeeded(buf, 1568);
     assertEquals(ext, ".jpg");
 
-    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    const resized = await Jimp.fromBuffer(new Uint8Array(result).buffer);
     assertEquals(resized.height, 1568);
     assertEquals(resized.width <= 1568, true);
   });
@@ -259,7 +259,7 @@ Deno.test("resizeImageIfNeeded", async (t) => {
     const [result, ext] = await resizeImageIfNeeded(buf, 50);
     assertEquals(ext, ".jpg");
 
-    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    const resized = await Jimp.fromBuffer(new Uint8Array(result).buffer);
     assertEquals(resized.width, 50);
   });
 });

--- a/bot/message.test.ts
+++ b/bot/message.test.ts
@@ -1,6 +1,15 @@
 import { assertEquals } from "@std/assert";
 import type { GuildTextBasedChannel } from "discord.js";
-import { createProgressReporter, keepTyping, splitMessage } from "./message.ts";
+import { Jimp } from "jimp";
+import {
+  appendImageReferences,
+  cleanupImageFiles,
+  createProgressReporter,
+  type DownloadedImage,
+  keepTyping,
+  resizeImageIfNeeded,
+  splitMessage,
+} from "./message.ts";
 
 Deno.test("splitMessage", async (t) => {
   await t.step("短いテキストは 1 チャンクで返すこと", () => {
@@ -198,4 +207,113 @@ Deno.test("createProgressReporter", async (t) => {
       assertEquals(calls.length, 0);
     },
   );
+});
+
+/** テスト用の PNG バッファを生成する。 */
+async function createTestPng(
+  width: number,
+  height: number,
+): Promise<Uint8Array> {
+  const img = new Jimp({ width, height, color: 0xff0000ff });
+  const buf = await img.getBuffer("image/png");
+  return new Uint8Array(buf);
+}
+
+Deno.test("resizeImageIfNeeded", async (t) => {
+  await t.step("小さい画像はリサイズされないこと", async () => {
+    const buf = await createTestPng(800, 600);
+    const [result, ext] = await resizeImageIfNeeded(buf, 1568);
+    assertEquals(ext, "");
+    assertEquals(result, buf);
+  });
+
+  await t.step("幅が長辺の場合にリサイズされること", async () => {
+    const buf = await createTestPng(3000, 2000);
+    const [result, ext] = await resizeImageIfNeeded(buf, 1568);
+    assertEquals(ext, ".jpg");
+
+    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    assertEquals(resized.width, 1568);
+    assertEquals(resized.height <= 1568, true);
+  });
+
+  await t.step("高さが長辺の場合にリサイズされること", async () => {
+    const buf = await createTestPng(1000, 3000);
+    const [result, ext] = await resizeImageIfNeeded(buf, 1568);
+    assertEquals(ext, ".jpg");
+
+    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    assertEquals(resized.height, 1568);
+    assertEquals(resized.width <= 1568, true);
+  });
+
+  await t.step("ちょうど最大サイズの場合はリサイズされないこと", async () => {
+    const buf = await createTestPng(1568, 1000);
+    const [result, ext] = await resizeImageIfNeeded(buf, 1568);
+    assertEquals(ext, "");
+    assertEquals(result, buf);
+  });
+
+  await t.step("カスタム最大サイズで動作すること", async () => {
+    const buf = await createTestPng(200, 100);
+    const [result, ext] = await resizeImageIfNeeded(buf, 50);
+    assertEquals(ext, ".jpg");
+
+    const resized = await Jimp.fromBuffer(result.buffer as ArrayBuffer);
+    assertEquals(resized.width, 50);
+  });
+});
+
+Deno.test("appendImageReferences", async (t) => {
+  await t.step("画像がない場合はプロンプトがそのまま返ること", () => {
+    assertEquals(appendImageReferences("hello", []), "hello");
+  });
+
+  await t.step("単一画像の参照が付加されること", () => {
+    const images: DownloadedImage[] = [
+      { path: "/tmp/test/a.jpg", originalName: "photo.jpg" },
+    ];
+    const result = appendImageReferences("describe this", images);
+    assertEquals(result, "describe this\n\n@/tmp/test/a.jpg");
+  });
+
+  await t.step("複数画像の参照がスペース区切りで付加されること", () => {
+    const images: DownloadedImage[] = [
+      { path: "/tmp/test/a.jpg", originalName: "a.jpg" },
+      { path: "/tmp/test/b.png", originalName: "b.png" },
+    ];
+    const result = appendImageReferences("what are these", images);
+    assertEquals(
+      result,
+      "what are these\n\n@/tmp/test/a.jpg @/tmp/test/b.png",
+    );
+  });
+});
+
+Deno.test("cleanupImageFiles", async (t) => {
+  await t.step("一時ディレクトリが削除されること", async () => {
+    const dir = await Deno.makeTempDir({ prefix: "loms-claw-test-" });
+    const filepath = `${dir}/test.jpg`;
+    await Deno.writeTextFile(filepath, "dummy");
+
+    const images: DownloadedImage[] = [
+      { path: filepath, originalName: "test.jpg" },
+    ];
+    await cleanupImageFiles(images);
+
+    let exists = true;
+    try {
+      await Deno.stat(dir);
+    } catch {
+      exists = false;
+    }
+    assertEquals(exists, false);
+  });
+
+  await t.step("既に削除済みでもエラーにならないこと", async () => {
+    const images: DownloadedImage[] = [
+      { path: "/tmp/nonexistent-dir-12345/test.jpg", originalName: "test.jpg" },
+    ];
+    await cleanupImageFiles(images);
+  });
 });

--- a/bot/message.ts
+++ b/bot/message.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Attachment, GuildTextBasedChannel } from "discord.js";
+import { dirname } from "@std/path/dirname";
 import { join } from "@std/path/join";
 import { Jimp } from "jimp";
 import { createLogger } from "../logger.ts";
@@ -43,7 +44,7 @@ export async function resizeImageIfNeeded(
   buffer: Uint8Array,
   maxDimension: number = MAX_IMAGE_DIMENSION,
 ): Promise<[Uint8Array, string]> {
-  const img = await Jimp.fromBuffer(buffer.buffer as ArrayBuffer);
+  const img = await Jimp.fromBuffer(new Uint8Array(buffer).buffer);
   const { width, height } = img;
   const longer = Math.max(width, height);
 
@@ -87,12 +88,14 @@ export async function downloadImageAttachments(
     return [];
   }
 
-  const dir = await Deno.makeTempDir({ prefix: "loms-claw-img-" });
+  let dir: string | null = null;
   const results: DownloadedImage[] = [];
 
   for (const att of images) {
     try {
-      const response = await fetch(att.url);
+      const response = await fetch(att.url, {
+        signal: AbortSignal.timeout(30_000),
+      });
       if (!response.ok) {
         log.warn(
           `failed to download attachment: ${att.name} (${response.status})`,
@@ -102,6 +105,11 @@ export async function downloadImageAttachments(
 
       const original = new Uint8Array(await response.arrayBuffer());
       const [data, resizedExt] = await resizeImageIfNeeded(original);
+
+      // 最初の成功時にディレクトリを作成。
+      if (!dir) {
+        dir = await Deno.makeTempDir({ prefix: "loms-claw-img-" });
+      }
 
       // リサイズされた場合は .jpg、されなかった場合は元の拡張子を維持。
       const ext = resizedExt ||
@@ -133,8 +141,7 @@ export async function cleanupImageFiles(
 ): Promise<void> {
   const dirs = new Set<string>();
   for (const img of images) {
-    const dir = img.path.substring(0, img.path.lastIndexOf("/"));
-    dirs.add(dir);
+    dirs.add(dirname(img.path));
   }
   for (const dir of dirs) {
     await Deno.remove(dir, { recursive: true }).catch(() => {});

--- a/bot/message.ts
+++ b/bot/message.ts
@@ -1,10 +1,161 @@
 /**
  * Discord メッセージ送信ユーティリティ。
  *
- * 2000 文字制限の分割送信と、typing インジケーター維持を提供する。
+ * 2000 文字制限の分割送信、typing インジケーター維持、
+ * 画像添付ファイルのダウンロードを提供する。
  */
 
-import type { GuildTextBasedChannel } from "discord.js";
+import type { Attachment, GuildTextBasedChannel } from "discord.js";
+import { join } from "@std/path/join";
+import { Jimp } from "jimp";
+import { createLogger } from "../logger.ts";
+
+const log = createLogger("message");
+
+/** 画像の content type プレフィックス。 */
+const IMAGE_CONTENT_TYPE_PREFIX = "image/";
+
+/** Claude Vision の推奨最大長辺（px）。 */
+const MAX_IMAGE_DIMENSION = 1568;
+
+/** リサイズ後の JPEG 品質。 */
+const JPEG_QUALITY = 80;
+
+/**
+ * ダウンロード済み画像の情報。
+ */
+export interface DownloadedImage {
+  /** 一時ファイルの絶対パス。 */
+  path: string;
+  /** 元のファイル名。 */
+  originalName: string;
+}
+
+/**
+ * 画像バッファを最大サイズ以内にリサイズする。
+ *
+ * 長辺が MAX_IMAGE_DIMENSION を超える場合のみ縮小し、JPEG で再エンコードする。
+ * 超えない場合は元のバッファをそのまま返す。
+ *
+ * @returns [リサイズ後バッファ, 拡張子]
+ */
+export async function resizeImageIfNeeded(
+  buffer: Uint8Array,
+  maxDimension: number = MAX_IMAGE_DIMENSION,
+): Promise<[Uint8Array, string]> {
+  const img = await Jimp.fromBuffer(buffer.buffer as ArrayBuffer);
+  const { width, height } = img;
+  const longer = Math.max(width, height);
+
+  if (longer <= maxDimension) {
+    return [buffer, ""];
+  }
+
+  if (width >= height) {
+    img.resize({ w: maxDimension });
+  } else {
+    img.resize({ h: maxDimension });
+  }
+
+  log.info(
+    `resized image: ${width}x${height} -> ${img.width}x${img.height}`,
+  );
+
+  const resized = await img.getBuffer("image/jpeg", { quality: JPEG_QUALITY });
+  return [new Uint8Array(resized), ".jpg"];
+}
+
+/**
+ * Discord メッセージの添付ファイルから画像をダウンロードし、一時ファイルに保存する。
+ *
+ * 長辺が 1568px を超える画像は自動的にリサイズされる。
+ *
+ * @param attachments - Discord メッセージの添付ファイルコレクション。
+ * @returns ダウンロード済み画像情報の配列。呼び出し側で一時ファイルの削除を行うこと。
+ */
+export async function downloadImageAttachments(
+  attachments: Iterable<Attachment>,
+): Promise<DownloadedImage[]> {
+  const images: Attachment[] = [];
+  for (const att of attachments) {
+    if (att.contentType?.startsWith(IMAGE_CONTENT_TYPE_PREFIX)) {
+      images.push(att);
+    }
+  }
+
+  if (images.length === 0) {
+    return [];
+  }
+
+  const dir = await Deno.makeTempDir({ prefix: "loms-claw-img-" });
+  const results: DownloadedImage[] = [];
+
+  for (const att of images) {
+    try {
+      const response = await fetch(att.url);
+      if (!response.ok) {
+        log.warn(
+          `failed to download attachment: ${att.name} (${response.status})`,
+        );
+        continue;
+      }
+
+      const original = new Uint8Array(await response.arrayBuffer());
+      const [data, resizedExt] = await resizeImageIfNeeded(original);
+
+      // リサイズされた場合は .jpg、されなかった場合は元の拡張子を維持。
+      const ext = resizedExt ||
+        (att.name.lastIndexOf(".") !== -1
+          ? att.name.substring(att.name.lastIndexOf("."))
+          : ".bin");
+      const filename = `${crypto.randomUUID()}${ext}`;
+      const filepath = join(dir, filename);
+
+      await Deno.writeFile(filepath, data);
+      results.push({ path: filepath, originalName: att.name });
+      log.debug(`downloaded image: ${att.name} -> ${filepath}`);
+    } catch (e) {
+      log.warn(`failed to process attachment: ${att.name}`, e);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * 一時画像ファイルを削除する。
+ *
+ * ダウンロード先ディレクトリごと削除する。
+ * 異なるディレクトリに分散している場合はファイル単位で削除する。
+ */
+export async function cleanupImageFiles(
+  images: DownloadedImage[],
+): Promise<void> {
+  const dirs = new Set<string>();
+  for (const img of images) {
+    const dir = img.path.substring(0, img.path.lastIndexOf("/"));
+    dirs.add(dir);
+  }
+  for (const dir of dirs) {
+    await Deno.remove(dir, { recursive: true }).catch(() => {});
+  }
+}
+
+/**
+ * プロンプトに画像ファイル参照を付加する。
+ *
+ * claude -p の @ 構文で画像を参照できる形式にする。
+ */
+export function appendImageReferences(
+  prompt: string,
+  images: DownloadedImage[],
+): string {
+  if (images.length === 0) {
+    return prompt;
+  }
+  const refs = images.map((img) => `@${img.path}`).join(" ");
+  return `${prompt}\n\n${refs}`;
+}
 
 /**
  * Discord のメッセージ文字数上限。

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -290,13 +290,10 @@ export class DiscordBot {
     }
     prompt = prompt.trim();
 
-    // 画像添付ファイルの有無を確認
-    const hasImages = message.attachments.some((att) =>
-      att.contentType?.startsWith("image/")
-    );
+    const hasAttachments = message.attachments.size > 0;
 
-    // テキストも画像もなければ無視
-    if (!prompt && !hasImages) {
+    // テキストも添付もなければ無視
+    if (!prompt && !hasAttachments) {
       return;
     }
 
@@ -311,15 +308,22 @@ export class DiscordBot {
     let downloadedImages: DownloadedImage[] = [];
 
     try {
-      // 画像添付をダウンロード
-      if (hasImages) {
+      // 画像添付をダウンロード（画像フィルタは downloadImageAttachments 内で行う）
+      if (hasAttachments) {
         downloadedImages = await downloadImageAttachments(
           message.attachments.values(),
         );
-        prompt = appendImageReferences(
-          prompt || "この画像について説明して",
-          downloadedImages,
-        );
+        if (downloadedImages.length > 0) {
+          prompt = appendImageReferences(
+            prompt || "この画像について説明して",
+            downloadedImages,
+          );
+        }
+      }
+
+      // 画像ダウンロード後もプロンプトが空なら終了
+      if (!prompt) {
+        return;
       }
 
       const sessionId = this.sessions.get(channelId);

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -24,7 +24,15 @@ import { SessionStore } from "../session/mod.ts";
 import { ApprovalManager } from "../approval/manager.ts";
 import { command } from "./commands.ts";
 import { isAuthorized, shouldRespond } from "./guard.ts";
-import { createProgressReporter, keepTyping, splitMessage } from "./message.ts";
+import {
+  appendImageReferences,
+  cleanupImageFiles,
+  createProgressReporter,
+  type DownloadedImage,
+  downloadImageAttachments,
+  keepTyping,
+  splitMessage,
+} from "./message.ts";
 import { join } from "jsr:@std/path@^1/join";
 import { createLogger } from "../logger.ts";
 import { SystemPromptStore } from "../claude/system-prompt.ts";
@@ -281,7 +289,14 @@ export class DiscordBot {
       );
     }
     prompt = prompt.trim();
-    if (!prompt) {
+
+    // 画像添付ファイルの有無を確認
+    const hasImages = message.attachments.some((att) =>
+      att.contentType?.startsWith("image/")
+    );
+
+    // テキストも画像もなければ無視
+    if (!prompt && !hasImages) {
       return;
     }
 
@@ -293,8 +308,20 @@ export class DiscordBot {
     keepTyping(channel, typingController.signal);
 
     const progress = createProgressReporter(channel);
+    let downloadedImages: DownloadedImage[] = [];
 
     try {
+      // 画像添付をダウンロード
+      if (hasImages) {
+        downloadedImages = await downloadImageAttachments(
+          message.attachments.values(),
+        );
+        prompt = appendImageReferences(
+          prompt || "この画像について説明して",
+          downloadedImages,
+        );
+      }
+
       const sessionId = this.sessions.get(channelId);
 
       // 承認ボタンの送信先チャンネルを設定
@@ -356,6 +383,9 @@ export class DiscordBot {
       log.error("failed to process message:", errMsg);
       await channel.send(`Error: ${errMsg}`).catch(() => {});
     } finally {
+      if (downloadedImages.length > 0) {
+        await cleanupImageFiles(downloadedImages);
+      }
       await progress.cleanup();
       typingController.abort();
     }

--- a/deno.json
+++ b/deno.json
@@ -13,12 +13,13 @@
     "@discordjs/voice": "npm:@discordjs/voice@0.19.2",
     "@openai/openai": "jsr:@openai/openai@^6.33.0",
     "@snazzah/davey": "npm:@snazzah/davey@^0.1.11",
-    "discord.js": "npm:discord.js@^14.25.1",
+    "discord.js": "npm:discord.js@^14.26.0",
     "opusscript": "npm:opusscript@0.1.1",
     "@std/assert": "jsr:@std/assert@^1.0.19",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.6",
     "@std/path": "jsr:@std/path@^1.1.4",
-    "@std/streams": "jsr:@std/streams@^1.0.17"
+    "@std/streams": "jsr:@std/streams@^1.0.17",
+    "jimp": "npm:jimp@^1.6.0"
   },
   "tasks": {
     "start": "deno run -A main.ts",

--- a/deno.lock
+++ b/deno.lock
@@ -10,18 +10,23 @@
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/streams@^1.0.17": "1.0.17",
-    "npm:@anthropic-ai/claude-agent-sdk@~0.2.88": "0.2.88_zod@4.3.6",
+    "npm:@anthropic-ai/claude-agent-sdk@~0.2.88": "0.2.88_zod@3.25.76",
     "npm:@discordjs/voice@0.19.2": "0.19.2_opusscript@0.1.1",
     "npm:@snazzah/davey@~0.1.11": "0.1.11",
-    "npm:discord.js@^14.25.1": "14.25.1",
-    "npm:opusscript@0.1.1": "0.1.1"
+    "npm:discord.js@^14.26.0": "14.26.0",
+    "npm:jimp@^1.6.0": "1.6.0",
+    "npm:opusscript@0.1.1": "0.1.1",
+    "npm:zod@3": "3.25.76"
   },
   "jsr": {
     "@aireone/deno-lint-curly@0.2.0": {
       "integrity": "c182ea5d2ed999c06ffa88a21aac2aed3cf0d14a1128d7fad3034337f7822b48"
     },
     "@openai/openai@6.33.0": {
-      "integrity": "292fec0ff0fd8b04f25e0ccbee8a06895b423abfb5113b9076e4ae39b4a18721"
+      "integrity": "292fec0ff0fd8b04f25e0ccbee8a06895b423abfb5113b9076e4ae39b4a18721",
+      "dependencies": [
+        "npm:zod"
+      ]
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -52,7 +57,7 @@
     }
   },
   "npm": {
-    "@anthropic-ai/claude-agent-sdk@0.2.88_zod@4.3.6": {
+    "@anthropic-ai/claude-agent-sdk@0.2.88_zod@3.25.76": {
       "integrity": "sha512-hm9AYD8UGpGouOlmWB6kMRjIUCMtO13N3HDsviu7/htOXJZ/KKypgEd5yW04Ro6421SwX4KfQNrwayJ6R227+g==",
       "dependencies": [
         "@anthropic-ai/sdk",
@@ -71,7 +76,7 @@
         "@img/sharp-win32-x64"
       ]
     },
-    "@anthropic-ai/sdk@0.74.0_zod@4.3.6": {
+    "@anthropic-ai/sdk@0.74.0_zod@3.25.76": {
       "integrity": "sha512-srbJV7JKsc5cQ6eVuFzjZO7UR3xEPJqPamHFIe29bs38Ij2IripoAhC0S5NslNbaFUYqBKypmmpzMTpqfHEUDw==",
       "dependencies": [
         "json-schema-to-ts",
@@ -120,7 +125,7 @@
         "discord-api-types",
         "magic-bytes.js",
         "tslib",
-        "undici@6.24.1"
+        "undici"
       ]
     },
     "@discordjs/util@1.2.0": {
@@ -280,7 +285,251 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@modelcontextprotocol/sdk@1.29.0_zod@4.3.6_hono@4.12.9_ajv@8.18.0_express@5.2.1": {
+    "@jimp/core@1.6.0": {
+      "integrity": "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w==",
+      "dependencies": [
+        "@jimp/file-ops",
+        "@jimp/types",
+        "@jimp/utils",
+        "await-to-js",
+        "exif-parser",
+        "file-type",
+        "mime"
+      ]
+    },
+    "@jimp/diff@1.6.0": {
+      "integrity": "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw==",
+      "dependencies": [
+        "@jimp/plugin-resize",
+        "@jimp/types",
+        "@jimp/utils",
+        "pixelmatch"
+      ]
+    },
+    "@jimp/file-ops@1.6.0": {
+      "integrity": "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="
+    },
+    "@jimp/js-bmp@1.6.0": {
+      "integrity": "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "@jimp/utils",
+        "bmp-ts"
+      ]
+    },
+    "@jimp/js-gif@1.6.0": {
+      "integrity": "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "gifwrap",
+        "omggif"
+      ]
+    },
+    "@jimp/js-jpeg@1.6.0": {
+      "integrity": "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "jpeg-js"
+      ]
+    },
+    "@jimp/js-png@1.6.0": {
+      "integrity": "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "pngjs@7.0.0"
+      ]
+    },
+    "@jimp/js-tiff@1.6.0": {
+      "integrity": "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "utif2"
+      ]
+    },
+    "@jimp/plugin-blit@1.6.0": {
+      "integrity": "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA==",
+      "dependencies": [
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-blur@1.6.0": {
+      "integrity": "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/utils"
+      ]
+    },
+    "@jimp/plugin-circle@1.6.0": {
+      "integrity": "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw==",
+      "dependencies": [
+        "@jimp/types",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-color@1.6.0": {
+      "integrity": "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "@jimp/utils",
+        "tinycolor2",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-contain@1.6.0": {
+      "integrity": "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/plugin-blit",
+        "@jimp/plugin-resize",
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-cover@1.6.0": {
+      "integrity": "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/plugin-crop",
+        "@jimp/plugin-resize",
+        "@jimp/types",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-crop@1.6.0": {
+      "integrity": "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-displace@1.6.0": {
+      "integrity": "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q==",
+      "dependencies": [
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-dither@1.6.0": {
+      "integrity": "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ==",
+      "dependencies": [
+        "@jimp/types"
+      ]
+    },
+    "@jimp/plugin-fisheye@1.6.0": {
+      "integrity": "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA==",
+      "dependencies": [
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-flip@1.6.0": {
+      "integrity": "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg==",
+      "dependencies": [
+        "@jimp/types",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-hash@1.6.0": {
+      "integrity": "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/js-bmp",
+        "@jimp/js-jpeg",
+        "@jimp/js-png",
+        "@jimp/js-tiff",
+        "@jimp/plugin-color",
+        "@jimp/plugin-resize",
+        "@jimp/types",
+        "@jimp/utils",
+        "any-base"
+      ]
+    },
+    "@jimp/plugin-mask@1.6.0": {
+      "integrity": "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA==",
+      "dependencies": [
+        "@jimp/types",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-print@1.6.0": {
+      "integrity": "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/js-jpeg",
+        "@jimp/js-png",
+        "@jimp/plugin-blit",
+        "@jimp/types",
+        "parse-bmfont-ascii",
+        "parse-bmfont-binary",
+        "parse-bmfont-xml",
+        "simple-xml-to-json",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-quantize@1.6.0": {
+      "integrity": "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg==",
+      "dependencies": [
+        "image-q",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-resize@1.6.0": {
+      "integrity": "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/types",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-rotate@1.6.0": {
+      "integrity": "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/plugin-crop",
+        "@jimp/plugin-resize",
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/plugin-threshold@1.6.0": {
+      "integrity": "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/plugin-color",
+        "@jimp/plugin-hash",
+        "@jimp/types",
+        "@jimp/utils",
+        "zod"
+      ]
+    },
+    "@jimp/types@1.6.0": {
+      "integrity": "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg==",
+      "dependencies": [
+        "zod"
+      ]
+    },
+    "@jimp/utils@1.6.0": {
+      "integrity": "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA==",
+      "dependencies": [
+        "@jimp/types",
+        "tinycolor2"
+      ]
+    },
+    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76_hono@4.12.9_ajv@8.18.0_express@5.2.1": {
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dependencies": [
         "@hono/node-server",
@@ -417,17 +666,17 @@
         "@snazzah/davey-win32-x64-msvc"
       ]
     },
+    "@tokenizer/token@0.3.0": {
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
+    },
     "@tybys/wasm-util@0.10.1": {
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
       "dependencies": [
         "tslib"
       ]
     },
-    "@types/node@25.5.0": {
-      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
-      "dependencies": [
-        "undici-types"
-      ]
+    "@types/node@16.9.1": {
+      "integrity": "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="
     },
     "@types/ws@8.18.1": {
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
@@ -437,6 +686,12 @@
     },
     "@vladfrangu/async_event_emitter@2.4.7": {
       "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="
+    },
+    "abort-controller@3.0.0": {
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "dependencies": [
+        "event-target-shim"
+      ]
     },
     "accepts@2.0.0": {
       "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
@@ -463,6 +718,18 @@
         "require-from-string"
       ]
     },
+    "any-base@1.1.0": {
+      "integrity": "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="
+    },
+    "await-to-js@3.0.0": {
+      "integrity": "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="
+    },
+    "base64-js@1.5.1": {
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bmp-ts@1.0.9": {
+      "integrity": "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="
+    },
     "body-parser@2.2.2": {
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": [
@@ -475,6 +742,13 @@
         "qs",
         "raw-body",
         "type-is"
+      ]
+    },
+    "buffer@6.0.3": {
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dependencies": [
+        "base64-js",
+        "ieee754"
       ]
     },
     "bytes@3.1.2": {
@@ -533,8 +807,8 @@
     "discord-api-types@0.38.43": {
       "integrity": "sha512-sSoBf/nK6m7BGtw65mi+QBuvEWaHE8MMziFLqWL+gT6ME/BLg34dRSVKS3Husx40uU06bvxUc3/X+D9Y6/zAbw=="
     },
-    "discord.js@14.25.1": {
-      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
+    "discord.js@14.26.0": {
+      "integrity": "sha512-I+5dmdg7WnjIOEXspX6mJ4jLgblhZV6QpQcC3U2JjrFWnHCKDpoLkhV46SBP8k9QePs3YWJOvndVutUARRO0AQ==",
       "dependencies": [
         "@discordjs/builders",
         "@discordjs/collection@1.5.3",
@@ -548,7 +822,7 @@
         "lodash.snakecase",
         "magic-bytes.js",
         "tslib",
-        "undici@6.21.3"
+        "undici"
       ]
     },
     "dunder-proto@1.0.1": {
@@ -583,6 +857,12 @@
     "etag@1.8.1": {
       "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="
     },
+    "event-target-shim@5.0.1": {
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
+    "events@3.3.0": {
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
+    },
     "eventsource-parser@3.0.6": {
       "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="
     },
@@ -591,6 +871,9 @@
       "dependencies": [
         "eventsource-parser"
       ]
+    },
+    "exif-parser@0.1.12": {
+      "integrity": "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="
     },
     "express-rate-limit@8.3.2_express@5.2.1": {
       "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
@@ -638,6 +921,14 @@
     "fast-uri@3.1.0": {
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="
     },
+    "file-type@16.5.4": {
+      "integrity": "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==",
+      "dependencies": [
+        "readable-web-to-node-stream",
+        "strtok3",
+        "token-types"
+      ]
+    },
     "finalhandler@2.1.1": {
       "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
       "dependencies": [
@@ -680,6 +971,13 @@
         "es-object-atoms"
       ]
     },
+    "gifwrap@0.10.1": {
+      "integrity": "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw==",
+      "dependencies": [
+        "image-q",
+        "omggif"
+      ]
+    },
     "gopd@1.2.0": {
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="
     },
@@ -711,6 +1009,15 @@
         "safer-buffer"
       ]
     },
+    "ieee754@1.2.1": {
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "image-q@4.0.0": {
+      "integrity": "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw==",
+      "dependencies": [
+        "@types/node"
+      ]
+    },
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
@@ -726,8 +1033,43 @@
     "isexe@2.0.0": {
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "jimp@1.6.0": {
+      "integrity": "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg==",
+      "dependencies": [
+        "@jimp/core",
+        "@jimp/diff",
+        "@jimp/js-bmp",
+        "@jimp/js-gif",
+        "@jimp/js-jpeg",
+        "@jimp/js-png",
+        "@jimp/js-tiff",
+        "@jimp/plugin-blit",
+        "@jimp/plugin-blur",
+        "@jimp/plugin-circle",
+        "@jimp/plugin-color",
+        "@jimp/plugin-contain",
+        "@jimp/plugin-cover",
+        "@jimp/plugin-crop",
+        "@jimp/plugin-displace",
+        "@jimp/plugin-dither",
+        "@jimp/plugin-fisheye",
+        "@jimp/plugin-flip",
+        "@jimp/plugin-hash",
+        "@jimp/plugin-mask",
+        "@jimp/plugin-print",
+        "@jimp/plugin-quantize",
+        "@jimp/plugin-resize",
+        "@jimp/plugin-rotate",
+        "@jimp/plugin-threshold",
+        "@jimp/types",
+        "@jimp/utils"
+      ]
+    },
     "jose@6.2.2": {
       "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ=="
+    },
+    "jpeg-js@0.4.4": {
+      "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="
     },
     "json-schema-to-ts@3.1.1": {
       "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
@@ -769,6 +1111,10 @@
         "mime-db"
       ]
     },
+    "mime@3.0.0": {
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "bin": true
+    },
     "ms@2.1.3": {
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
@@ -780,6 +1126,9 @@
     },
     "object-inspect@1.13.4": {
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="
+    },
+    "omggif@1.0.10": {
+      "integrity": "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="
     },
     "on-finished@2.4.1": {
       "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
@@ -796,6 +1145,22 @@
     "opusscript@0.1.1": {
       "integrity": "sha512-mL0fZZOUnXdZ78woRXp18lApwpp0lF5tozJOD1Wut0dgrA9WuQTgSels/CSmFleaAZrJi/nci5KOVtbuxeWoQA=="
     },
+    "pako@1.0.11": {
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "parse-bmfont-ascii@1.0.6": {
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
+    },
+    "parse-bmfont-binary@1.0.6": {
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
+    },
+    "parse-bmfont-xml@1.1.6": {
+      "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
+      "dependencies": [
+        "xml-parse-from-string",
+        "xml2js"
+      ]
+    },
     "parseurl@1.3.3": {
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
@@ -805,8 +1170,24 @@
     "path-to-regexp@8.4.1": {
       "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw=="
     },
+    "peek-readable@4.1.0": {
+      "integrity": "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="
+    },
+    "pixelmatch@5.3.0": {
+      "integrity": "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q==",
+      "dependencies": [
+        "pngjs@6.0.0"
+      ],
+      "bin": true
+    },
     "pkce-challenge@5.0.1": {
       "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="
+    },
+    "pngjs@6.0.0": {
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
+    },
+    "pngjs@7.0.0": {
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="
     },
     "prism-media@1.3.5_opusscript@0.1.1": {
       "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
@@ -816,6 +1197,9 @@
       "optionalPeers": [
         "opusscript"
       ]
+    },
+    "process@0.11.10": {
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
     },
     "proxy-addr@2.0.7": {
       "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
@@ -842,6 +1226,22 @@
         "unpipe"
       ]
     },
+    "readable-stream@4.7.0": {
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "dependencies": [
+        "abort-controller",
+        "buffer",
+        "events",
+        "process",
+        "string_decoder"
+      ]
+    },
+    "readable-web-to-node-stream@3.0.4": {
+      "integrity": "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==",
+      "dependencies": [
+        "readable-stream"
+      ]
+    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
@@ -855,8 +1255,14 @@
         "path-to-regexp"
       ]
     },
+    "safe-buffer@5.2.1": {
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
     "safer-buffer@2.1.2": {
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "sax@1.6.0": {
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="
     },
     "send@1.2.1": {
       "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
@@ -931,11 +1337,37 @@
         "side-channel-weakmap"
       ]
     },
+    "simple-xml-to-json@1.2.4": {
+      "integrity": "sha512-3MY16e0ocMHL7N1ufpdObURGyX+lCo0T/A+y6VCwosLdH1HSda4QZl1Sdt/O+2qWp48WFi26XEp5rF0LoaL0Dg=="
+    },
     "statuses@2.0.2": {
       "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="
     },
+    "string_decoder@1.3.0": {
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": [
+        "safe-buffer"
+      ]
+    },
+    "strtok3@6.3.0": {
+      "integrity": "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==",
+      "dependencies": [
+        "@tokenizer/token",
+        "peek-readable"
+      ]
+    },
+    "tinycolor2@1.6.0": {
+      "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="
+    },
     "toidentifier@1.0.1": {
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
+    },
+    "token-types@4.2.1": {
+      "integrity": "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==",
+      "dependencies": [
+        "@tokenizer/token",
+        "ieee754"
+      ]
     },
     "ts-algebra@2.0.0": {
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw=="
@@ -954,17 +1386,17 @@
         "mime-types"
       ]
     },
-    "undici-types@7.18.2": {
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="
-    },
-    "undici@6.21.3": {
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw=="
-    },
     "undici@6.24.1": {
       "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
     },
     "unpipe@1.0.0": {
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="
+    },
+    "utif2@4.1.0": {
+      "integrity": "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w==",
+      "dependencies": [
+        "pako"
+      ]
     },
     "vary@1.1.2": {
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
@@ -982,14 +1414,27 @@
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
-    "zod-to-json-schema@3.25.2_zod@4.3.6": {
+    "xml-parse-from-string@1.0.1": {
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
+    },
+    "xml2js@0.5.0": {
+      "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+      "dependencies": [
+        "sax",
+        "xmlbuilder"
+      ]
+    },
+    "xmlbuilder@11.0.1": {
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "zod-to-json-schema@3.25.2_zod@3.25.76": {
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dependencies": [
         "zod"
       ]
     },
-    "zod@4.3.6": {
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "workspace": {
@@ -1002,7 +1447,8 @@
       "npm:@anthropic-ai/claude-agent-sdk@~0.2.88",
       "npm:@discordjs/voice@0.19.2",
       "npm:@snazzah/davey@~0.1.11",
-      "npm:discord.js@^14.25.1",
+      "npm:discord.js@^14.26.0",
+      "npm:jimp@^1.6.0",
       "npm:opusscript@0.1.1"
     ]
   }

--- a/voice/codec.ts
+++ b/voice/codec.ts
@@ -26,6 +26,27 @@ export function createOpusDecoder(): OpusDecoder {
 }
 
 /**
+ * 複数の Buffer を結合して単一の Buffer を返す。
+ *
+ * `@types/node` のバージョン間で `Buffer` が `Uint8Array` の
+ * サブタイプとして認識されない場合があるため、
+ * `Buffer.concat` の代わりにこの関数を使用する。
+ */
+export function concatBytes(...arrays: Buffer[]): Buffer {
+  const totalLength = arrays.reduce((sum, a) => sum + a.length, 0);
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(
+      new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength),
+      offset,
+    );
+    offset += arr.length;
+  }
+  return Buffer.from(result.buffer);
+}
+
+/**
  * 生 PCM データに WAV コンテナの 44 バイトヘッダを付与する。
  *
  * 48 kHz、モノラル、16 ビット リトルエンディアン PCM を前提とする。
@@ -55,7 +76,7 @@ export function pcmToWav(pcm: Buffer): Buffer {
   header.write("data", 36);
   header.writeUInt32LE(dataSize, 40);
 
-  return Buffer.concat([header, pcm]);
+  return concatBytes(header, pcm);
 }
 
 /**

--- a/voice/codec.ts
+++ b/voice/codec.ts
@@ -26,7 +26,7 @@ export function createOpusDecoder(): OpusDecoder {
 }
 
 /**
- * 複数の Buffer を結合して単一の Buffer を返す。
+ * 複数の Uint8Array / Buffer を結合して単一の Buffer を返す。
  *
  * `@types/node` のバージョン間で `Buffer` が `Uint8Array` の
  * サブタイプとして認識されない場合があるため、

--- a/voice/mod.ts
+++ b/voice/mod.ts
@@ -21,7 +21,7 @@ import type { SessionStore } from "../session/mod.ts";
 import type { ApprovalManager } from "../approval/manager.ts";
 import { createLogger } from "../logger.ts";
 import type { SystemPromptStore } from "../claude/system-prompt.ts";
-import { calcRms, createOpusDecoder } from "./codec.ts";
+import { calcRms, concatBytes, createOpusDecoder } from "./codec.ts";
 import type { SpeechToText } from "./stt.ts";
 import type { VoicePlayer } from "./player.ts";
 import { askClaudeForVoice } from "./adapter.ts";
@@ -337,7 +337,7 @@ export class VoiceManager {
         return;
       }
 
-      const pcm = Buffer.concat(pcmChunks);
+      const pcm = concatBytes(...pcmChunks);
 
       if (pcm.length < this.minPcmBytes) {
         log.debug("audio too short, skipping");

--- a/voice/tones.test.ts
+++ b/voice/tones.test.ts
@@ -16,7 +16,7 @@ Deno.test("generateThinkingTone", async (t) => {
   await t.step("呼び出しごとに同じ結果を返すこと", () => {
     const a = generateThinkingTone();
     const b = generateThinkingTone();
-    assertEquals(a.equals(b), true);
+    assertEquals(a.every((v, i) => v === b[i]) && a.length === b.length, true);
   });
 });
 
@@ -30,6 +30,10 @@ Deno.test("generateErrorTone", async (t) => {
   await t.step("thinking tone とは異なるバイト列であること", () => {
     const thinking = generateThinkingTone();
     const error = generateErrorTone();
-    assertEquals(thinking.equals(error), false);
+    assertEquals(
+      thinking.length !== error.length ||
+        thinking.some((v, i) => v !== error[i]),
+      true,
+    );
   });
 });

--- a/voice/tones.ts
+++ b/voice/tones.ts
@@ -9,7 +9,7 @@
  */
 
 import { Buffer } from "node:buffer";
-import { pcmToWav } from "./codec.ts";
+import { concatBytes, pcmToWav } from "./codec.ts";
 
 /** サンプリングレート（Hz）。Discord の音声フォーマットに合わせる。 */
 const SAMPLE_RATE = 48000;
@@ -107,7 +107,7 @@ function generateSilence(durationMs: number): Buffer {
 export function generateThinkingTone(): Buffer {
   const note = generateMarimbaTone(262, 200, 0.15); // C4
   const silence = generateSilence(550);
-  return pcmToWav(Buffer.concat([note, silence]));
+  return pcmToWav(concatBytes(note, silence));
 }
 
 /**
@@ -122,5 +122,5 @@ export function generateErrorTone(): Buffer {
   const high = generateMarimbaTone(165, 200, 0.2); // E3
   const gap = generateSilence(80);
   const low = generateMarimbaTone(131, 300, 0.2); // C3
-  return pcmToWav(Buffer.concat([high, gap, low]));
+  return pcmToWav(concatBytes(high, gap, low));
 }


### PR DESCRIPTION
## Summary

- Discord メッセージの画像添付を検出し、`claude -p` の `@` 構文で Claude に渡す機能を追加
- 長辺 1568px 超の画像は `jimp` で自動リサイズ（JPEG 80%）してトークン消費を抑制
- discord.js 14.26.0 更新に伴う `Buffer`/`Uint8Array` 型互換の修正（`voice/` 配下）

## 変更内容

### 新機能（`bot/message.ts`）
- `downloadImageAttachments()`: 添付画像のダウンロード + 一時ファイル保存
- `resizeImageIfNeeded()`: 長辺が閾値を超える画像の自動リサイズ
- `appendImageReferences()`: プロンプトへの `@/path/to/image` 参照付加
- `cleanupImageFiles()`: 一時ファイルの削除

### メッセージハンドラ変更（`bot/mod.ts`）
- `onMessage` で画像添付を検出→ダウンロード→プロンプトに付加→一時ファイル削除
- テキストなし画像のみのメッセージにも対応（デフォルトプロンプト付与）

### 依存更新
- `jimp@^1.6.0` 追加（純 JS 画像処理、native binding 不要）
- `discord.js` ^14.25.1 → ^14.26.0

### 型互換修正（`voice/`）
- `concatBytes()` ユーティリティ追加で `Buffer.concat` の型エラーを解消
- `tones.test.ts` のバッファ比較を `Buffer` 非依存に変更

## Test plan

- [x] `deno task check` — 型エラーなし
- [x] `deno task test` — 26 テスト、133 ステップ全通過
- [x] `deno task lint` — lint + format 通過
- [ ] 実環境で Discord に画像を添付して送信し、Claude が画像を認識して応答することを確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)