### PR TITLE
fix: VC発話処理の Claude CLI 重複実行を防止

### DIFF
--- a/docker/claude-workspace/.claude/settings.json
+++ b/docker/claude-workspace/.claude/settings.json
@@ -16,7 +16,10 @@
       "Read",
       "Write",
       "Edit",
-      "Skill"
+      "Skill",
+      "WebFetch",
+      "Agent",
+      "Grep"
     ]
   }
 }

--- a/voice/mod.ts
+++ b/voice/mod.ts
@@ -50,6 +50,7 @@ export class VoiceManager {
     displayName: string;
     timer: ReturnType<typeof setTimeout>;
   }>();
+  private readonly processingUsers = new Set<string>();
 
   constructor(
     private readonly voiceConfig: VoiceConfig,
@@ -422,8 +423,16 @@ export class VoiceManager {
 
   /**
    * デバウンスバッファをフラッシュし、Claude CLI → TTS パイプラインを実行する。
+   * 同一ユーザーの並行実行を防ぐ排他制御付き。
    */
   private async flushSpeech(userId: string): Promise<void> {
+    if (this.processingUsers.has(userId)) {
+      // 前の実行が完了するまでバッファに残しておく。
+      // 完了後に再フラッシュされる。
+      log.debug(`skipping flush for ${userId} (already processing)`);
+      return;
+    }
+
     const entry = this.speechDebounce.get(userId);
     this.speechDebounce.delete(userId);
     if (!entry || entry.texts.length === 0) {
@@ -436,6 +445,7 @@ export class VoiceManager {
       return;
     }
 
+    this.processingUsers.add(userId);
     try {
       log.info(
         `sending to Claude (${entry.texts.length} segment(s)): ${mergedText}`,
@@ -484,6 +494,15 @@ export class VoiceManager {
       log.error(`pipeline error for user ${userId}:`, e);
       this.voicePlayer.stopThinking();
       this.voicePlayer.playErrorTone();
+    } finally {
+      this.processingUsers.delete(userId);
+      // 処理中に溜まった発話があれば再フラッシュする。
+      if (this.speechDebounce.has(userId)) {
+        log.info(`flushing queued speech for ${userId}`);
+        this.flushSpeech(userId).catch((e) =>
+          log.error(`flush error for user ${userId}:`, e)
+        );
+      }
     }
   }
 

--- a/voice/mod.ts
+++ b/voice/mod.ts
@@ -49,6 +49,7 @@ export class VoiceManager {
     texts: string[];
     displayName: string;
     timer: ReturnType<typeof setTimeout>;
+    timerActive: boolean;
   }>();
   private readonly processingUsers = new Set<string>();
 
@@ -163,6 +164,7 @@ export class VoiceManager {
       clearTimeout(entry.timer);
     }
     this.speechDebounce.clear();
+    this.processingUsers.clear();
     if (this.currentConnection) {
       try {
         this.currentConnection.destroy();
@@ -404,10 +406,15 @@ export class VoiceManager {
     const existing = this.speechDebounce.get(userId);
     const scheduleFlush = () =>
       setTimeout(
-        () =>
+        () => {
+          const entry = this.speechDebounce.get(userId);
+          if (entry) {
+            entry.timerActive = false;
+          }
           this.flushSpeech(userId).catch((e) =>
             log.error(`flush error for user ${userId}:`, e)
-          ),
+          );
+        },
         this.voiceConfig.speechDebounceMs,
       );
 
@@ -415,9 +422,15 @@ export class VoiceManager {
       clearTimeout(existing.timer);
       existing.texts.push(text);
       existing.timer = scheduleFlush();
+      existing.timerActive = true;
     } else {
       const timer = scheduleFlush();
-      this.speechDebounce.set(userId, { texts: [text], displayName, timer });
+      this.speechDebounce.set(userId, {
+        texts: [text],
+        displayName,
+        timer,
+        timerActive: true,
+      });
     }
   }
 
@@ -497,7 +510,10 @@ export class VoiceManager {
     } finally {
       this.processingUsers.delete(userId);
       // 処理中に溜まった発話があれば再フラッシュする。
-      if (this.speechDebounce.has(userId)) {
+      // ただしデバウンスタイマーがまだ動いている場合はタイマーに任せる
+      // （ユーザーがまだ話し続けている可能性がある）。
+      const pending = this.speechDebounce.get(userId);
+      if (pending && !pending.timerActive) {
         log.info(`flushing queued speech for ${userId}`);
         this.flushSpeech(userId).catch((e) =>
           log.error(`flush error for user ${userId}:`, e)


### PR DESCRIPTION
## Summary

- `VoiceManager.flushSpeech()` に `processingUsers` による排他制御を追加
- 同一ユーザーの Claude CLI 並行実行を防止し、処理中に溜まった発話は完了後に再フラッシュ

Closes #40

## Test plan

- [ ] VCで連続して発話し、Claude CLIが重複実行されないことをログで確認
- [ ] 前の応答完了後に次の発話が正常に処理されることを確認
- [ ] 型チェック（`deno task check`）がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)