### PR TITLE
feat: Claude CLI 応答のストリーミング対応

### DIFF
--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -405,6 +405,11 @@ export class DiscordBot {
           textBuffer.lastIndexOf("\n"),
         );
         if (lastBoundary < 0) {
+          // 境界が見つからないが閾値の 2 倍を超えたら強制フラッシュ。
+          // コードブロック・英語テキスト・URL 等が連続するケースへの対策。
+          if (textBuffer.length >= FLUSH_THRESHOLD * 2) {
+            await flushBuffer(true);
+          }
           return;
         }
         const send = textBuffer.slice(0, lastBoundary + 1).trim();
@@ -457,7 +462,9 @@ export class DiscordBot {
             await channel.send(chunk);
           }
         } else {
-          const errorDetail = resultEvent.subtype ?? "unknown error";
+          const errorDetail = resultEvent.errors
+            ? JSON.stringify(resultEvent.errors)
+            : resultEvent.subtype ?? "unknown error";
           throw new Error(`claude returned error: ${errorDetail}`);
         }
       }

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -18,7 +18,6 @@ import {
   Routes,
 } from "discord.js";
 import type { Config } from "../config.ts";
-import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
 import { askClaude } from "../claude/mod.ts";
 import { SessionStore } from "../session/mod.ts";
 import { ApprovalManager } from "../approval/manager.ts";
@@ -378,10 +377,65 @@ export class DiscordBot {
         appendSystemPrompt,
       });
 
-      let resultEvent: SDKResultMessage | undefined;
+      // ストリーミング応答: text_delta をバッファに蓄積し、
+      // 閾値を超えたら文境界で区切って中間投稿する。
+      const FLUSH_THRESHOLD = 800;
+      let textBuffer = "";
+      let hasStreamedText = false;
+      let hasResult = false;
+      // deno-lint-ignore no-explicit-any
+      let resultEvent: any;
+
+      const flushBuffer = async (force: boolean) => {
+        if (force) {
+          // 残り全部を投稿。
+          const text = textBuffer.trim();
+          textBuffer = "";
+          if (text) {
+            hasStreamedText = true;
+            for (const chunk of splitMessage(text)) {
+              await channel.send(chunk);
+            }
+          }
+          return;
+        }
+        // 最後の文境界（。、改行）で区切って投稿。
+        const lastBoundary = Math.max(
+          textBuffer.lastIndexOf("。"),
+          textBuffer.lastIndexOf("\n"),
+        );
+        if (lastBoundary < 0) {
+          return;
+        }
+        const send = textBuffer.slice(0, lastBoundary + 1).trim();
+        textBuffer = textBuffer.slice(lastBoundary + 1);
+        if (!send) {
+          return;
+        }
+        hasStreamedText = true;
+        for (const chunk of splitMessage(send)) {
+          await channel.send(chunk);
+        }
+      };
 
       for await (const event of stream) {
-        if (event.type === "result") {
+        if (
+          event.type === "stream_event" &&
+          !event.parent_tool_use_id
+        ) {
+          const e = event.event;
+          if (
+            e.type === "content_block_delta" &&
+            "text" in e.delta &&
+            e.delta.type === "text_delta"
+          ) {
+            textBuffer += e.delta.text;
+            if (textBuffer.length >= FLUSH_THRESHOLD) {
+              await flushBuffer(false);
+            }
+          }
+        } else if (event.type === "result") {
+          hasResult = true;
           resultEvent = event;
           // 非ゼロ終了でジェネレータがスローしてもセッションが残るよう即座に保存
           this.sessions.set(channelId, event.session_id);
@@ -390,21 +444,22 @@ export class DiscordBot {
         }
       }
 
-      if (!resultEvent) {
-        throw new Error("claude stream ended without result event");
-      }
+      // バッファに残ったテキストを投稿。
+      await flushBuffer(true);
 
-      // 応答送信
-      if ("result" in resultEvent && typeof resultEvent.result === "string") {
-        const chunks = splitMessage(resultEvent.result);
-        for (const chunk of chunks) {
-          await channel.send(chunk);
+      // stream_event がなかった場合は result.result からフォールバック。
+      if (!hasStreamedText) {
+        if (!hasResult) {
+          throw new Error("claude stream ended without result event");
         }
-      } else {
-        const errors = "errors" in resultEvent
-          ? JSON.stringify(resultEvent.errors)
-          : resultEvent.subtype ?? "unknown error";
-        throw new Error(`claude returned error: ${errors}`);
+        if (typeof resultEvent.result === "string") {
+          for (const chunk of splitMessage(resultEvent.result)) {
+            await channel.send(chunk);
+          }
+        } else {
+          const errorDetail = resultEvent.subtype ?? "unknown error";
+          throw new Error(`claude returned error: ${errorDetail}`);
+        }
       }
     } catch (error: unknown) {
       const errMsg = error instanceof Error ? error.message : String(error);

--- a/voice/adapter.ts
+++ b/voice/adapter.ts
@@ -3,6 +3,9 @@
  *
  * askClaude() が返す SDKMessage ストリームから結果テキストを抽出し、
  * 音声パイプラインが消費しやすい形で返す。
+ *
+ * streamClaudeForVoice() はストリーミング対応版で、text_delta を
+ * 文単位で逐次 yield し、TTS の体感遅延を最小化する。
  */
 
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
@@ -11,6 +14,13 @@ import type { ClaudeConfig } from "../config.ts";
 import { createLogger } from "../logger.ts";
 
 const log = createLogger("voice-adapter");
+
+/**
+ * streamClaudeForVoice が yield するイベント。
+ */
+export type VoiceStreamEvent =
+  | { type: "text"; text: string }
+  | { type: "end"; sessionId: string };
 
 /**
  * askClaudeForVoice の戻り値。
@@ -73,4 +83,117 @@ export async function askClaudeForVoice(
     ? JSON.stringify(resultEvent.errors)
     : resultEvent.subtype ?? "unknown error";
   throw new Error(`claude returned error: ${errors}`);
+}
+
+/**
+ * Claude Code CLI をストリーミングモードで呼び出し、
+ * テキストを文単位で逐次 yield する。
+ *
+ * stream_event の text_delta を蓄積し、文境界（。、改行）を検出したら
+ * その文を即座に yield する。呼び出し側は受け取った文を逐次 TTS に
+ * 渡すことで、応答全体の完了を待たずに音声再生を開始できる。
+ *
+ * サブエージェント（parent_tool_use_id !== null）のテキストは除外する。
+ *
+ * @param prompt - ユーザーの発話テキスト。
+ * @param options - Claude CLI オプション。
+ * @yields テキストチャンク（文単位）と終了イベント。
+ * @throws 結果イベントが無い場合、またはエラーイベントの場合。
+ */
+export async function* streamClaudeForVoice(
+  prompt: string,
+  options: {
+    sessionId?: string;
+    config: ClaudeConfig;
+    signal?: AbortSignal;
+    spawner?: CommandSpawner;
+    appendSystemPrompt?: string;
+  },
+): AsyncGenerator<VoiceStreamEvent> {
+  const stream = askClaude(prompt, options);
+  let buffer = "";
+  let sessionId = "";
+  let hasResult = false;
+  let hasStreamedText = false;
+  let resultText = "";
+
+  for await (const event of stream) {
+    // ストリーミングテキストチャンクの処理。
+    // parent_tool_use_id が falsy（null / undefined / 未設定）ならトップレベル。
+    if (
+      event.type === "stream_event" &&
+      !event.parent_tool_use_id
+    ) {
+      const e = event.event;
+      if (
+        e.type === "content_block_delta" &&
+        "text" in e.delta &&
+        e.delta.type === "text_delta"
+      ) {
+        buffer += e.delta.text;
+        // 文境界（。、改行）で分割し、完成した文を即座に yield。
+        const parts = buffer.split(/(?<=[。\n])/);
+        if (parts.length > 1) {
+          for (let i = 0; i < parts.length - 1; i++) {
+            const s = parts[i].trim();
+            if (s) {
+              hasStreamedText = true;
+              log.debug(`streaming chunk: "${s}"`);
+              yield { type: "text", text: s };
+            }
+          }
+          buffer = parts[parts.length - 1];
+        }
+      }
+    }
+
+    // result イベントからセッション ID とテキストを取得。
+    if (event.type === "result") {
+      hasResult = true;
+
+      // deno-lint-ignore no-explicit-any
+      const r = event as any;
+
+      // result フィールドがあればテキストとして採用する。
+      // error_max_turns 等でも result が含まれていればそれを使う
+      // （元の askClaudeForVoice と同じ挙動）。
+      if (typeof r.result === "string") {
+        sessionId = event.session_id;
+        resultText = r.result;
+      } else {
+        const errorDetail = r.subtype ?? "unknown error";
+        throw new Error(`claude returned error: ${errorDetail}`);
+      }
+    }
+  }
+
+  // バッファに残ったストリーミングテキストを flush。
+  const remaining = buffer.trim();
+  if (remaining) {
+    hasStreamedText = true;
+    log.debug(`streaming final chunk: "${remaining}"`);
+    yield { type: "text", text: remaining };
+  }
+
+  // stream_event が出力されなかった場合、result.result からテキストを抽出する。
+  if (!hasStreamedText && resultText) {
+    log.info("no stream_event received, falling back to result text");
+    const sentences = resultText
+      .split(/(?<=[。\n])/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    for (const s of sentences) {
+      yield { type: "text", text: s };
+    }
+  }
+
+  if (!hasResult) {
+    throw new Error("claude stream ended without result event");
+  }
+
+  log.info(
+    `voice stream completed (streamed=${hasStreamedText}, ` +
+      `resultLen=${resultText.length})`,
+  );
+  yield { type: "end", sessionId };
 }

--- a/voice/adapter.ts
+++ b/voice/adapter.ts
@@ -161,7 +161,9 @@ export async function* streamClaudeForVoice(
         sessionId = event.session_id;
         resultText = r.result;
       } else {
-        const errorDetail = r.subtype ?? "unknown error";
+        const errorDetail = r.errors
+          ? JSON.stringify(r.errors)
+          : r.subtype ?? "unknown error";
         throw new Error(`claude returned error: ${errorDetail}`);
       }
     }
@@ -175,6 +177,11 @@ export async function* streamClaudeForVoice(
     yield { type: "text", text: remaining };
   }
 
+  // hasStreamedText が true の場合、error_max_turns 等でも
+  // ストリーム済みテキストをそのまま使用する（resultText は無視）。
+  // ストリーミング中に yield 済みのテキストと resultText は同一内容のため、
+  // 二重に yield する必要はない。
+  //
   // stream_event が出力されなかった場合、result.result からテキストを抽出する。
   if (!hasStreamedText && resultText) {
     log.info("no stream_event received, falling back to result text");

--- a/voice/mod.ts
+++ b/voice/mod.ts
@@ -24,7 +24,7 @@ import type { SystemPromptStore } from "../claude/system-prompt.ts";
 import { calcRms, concatBytes, createOpusDecoder } from "./codec.ts";
 import type { SpeechToText } from "./stt.ts";
 import type { VoicePlayer } from "./player.ts";
-import { askClaudeForVoice } from "./adapter.ts";
+import { streamClaudeForVoice } from "./adapter.ts";
 
 const log = createLogger("voice");
 
@@ -487,21 +487,44 @@ export class VoiceManager {
         channelId,
         templateVars,
       );
-      const result = await askClaudeForVoice(mergedText, {
+
+      // ストリーミングで Claude CLI を呼び出し、文単位で逐次 TTS → 再生する。
+      const voiceStream = streamClaudeForVoice(mergedText, {
         sessionId,
         config: this.claudeConfig,
         signal: AbortSignal.timeout(this.claudeConfig.timeout),
         appendSystemPrompt,
       });
 
+      const player = this.voicePlayer;
+      let newSessionId = "";
+
+      // テキストチャンクだけを抽出する AsyncGenerator。
+      // 最初のチャンク到着時に thinking tone を停止する。
+      const textChunks = async function* () {
+        let thinkingStopped = false;
+        for await (const event of voiceStream) {
+          if (event.type === "text") {
+            if (!thinkingStopped) {
+              player.stopThinking();
+              thinkingStopped = true;
+            }
+            log.info(`reply chunk: ${event.text.slice(0, 200)}`);
+            yield event.text;
+          } else if (event.type === "end") {
+            newSessionId = event.sessionId;
+          }
+        }
+        if (!thinkingStopped) {
+          player.stopThinking();
+        }
+      };
+
+      await player.speakStreaming(textChunks());
+
       // セッション ID を保存。
-      this.sessions.set(channelId, result.sessionId);
-
-      this.voicePlayer.stopThinking();
-
-      if (result.text) {
-        log.info(`reply: ${result.text.slice(0, 200)}`);
-        await this.voicePlayer.speak(result.text);
+      if (newSessionId) {
+        this.sessions.set(channelId, newSessionId);
       }
     } catch (e: unknown) {
       log.error(`pipeline error for user ${userId}:`, e);

--- a/voice/player.ts
+++ b/voice/player.ts
@@ -246,6 +246,46 @@ export class VoicePlayer {
     }
   }
 
+  /**
+   * テキストチャンクを逐次受信し、到着順に合成・再生する。
+   *
+   * AsyncIterable から文を 1 つずつ受け取り、TTS 合成が完了次第
+   * 再生キューに追加する。interrupt() による中断にも対応する。
+   *
+   * @param chunks - 文単位のテキストを逐次 yield する AsyncIterable。
+   */
+  async speakStreaming(chunks: AsyncIterable<string>): Promise<void> {
+    const generation = ++this.speakGeneration;
+    log.info(`streaming speech started (gen=${generation})`);
+    this.isSpeaking = true;
+
+    for await (const chunk of chunks) {
+      if (this.speakGeneration !== generation) {
+        return;
+      }
+
+      log.debug(`synthesizing streaming chunk: "${chunk}"`);
+      const buf = await this.tts.synthesize(chunk);
+
+      if (this.speakGeneration !== generation) {
+        return;
+      }
+
+      this.isSpeaking = true;
+      if (buf.length > 0) {
+        this.queue.push(buf);
+        if (!this.isPlaying) {
+          this.playNext();
+        }
+      }
+    }
+
+    // 全チャンクが空だった場合のフォールバック。
+    if (!this.isPlaying && this.queue.length === 0) {
+      this.isSpeaking = false;
+    }
+  }
+
   private playNext(): void {
     if (this.queue.length === 0) {
       this.isPlaying = false;


### PR DESCRIPTION
## Summary

- Claude CLI の `stream_event` (`text_delta`) を文境界で区切って逐次処理し、応答全体の完了を待たずに TTS 再生・メッセージ投稿を開始する
- VC: `streamClaudeForVoice()` + `speakStreaming()` で到着した文から即座に TTS 合成→再生
- テキストチャンネル: 800 文字バッファリングで Discord rate limit 対策付きの中間投稿
- `stream_event` が出力されない CLI バージョンでは `result.result` からフォールバックし従来動作を維持

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `voice/adapter.ts` | `streamClaudeForVoice()` 追加、`VoiceStreamEvent` 型定義 |
| `voice/player.ts` | `speakStreaming()` 追加 |
| `voice/mod.ts` | `flushSpeech()` をストリーミング版に差し替え |
| `bot/mod.ts` | ストリーム処理ループにバッファリング付き中間投稿を追加 |

## Test plan

- [x] `deno task check` 型チェック通過
- [x] `deno task test` 全テスト通過（34 passed, 0 failed）
- [ ] VC で発話し、応答開始までの待ち時間が短縮されることを確認
- [ ] テキストチャンネルで長文応答時に中間投稿されることを確認
- [ ] `stream_event` 未対応環境でフォールバックが動作することを確認
- [ ] `error_max_turns` 時にテキストが正常に返ることを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)