### PR TITLE
fix: active channel で他ユーザー宛メンション・スレッドへの反応を抑制する

### DIFF
--- a/bot/guard.test.ts
+++ b/bot/guard.test.ts
@@ -64,49 +64,35 @@ const activeChannels = ["ch-active-1", "ch-active-2"];
 Deno.test("shouldRespond", async (t) => {
   await t.step("active channel では反応すること", () => {
     assertEquals(
-      shouldRespond("ch-active-1", activeChannels, false, null, false),
+      shouldRespond("ch-active-1", activeChannels, false, null, false, false),
       true,
     );
   });
 
   await t.step("非 active channel で mention なしの場合は無視すること", () => {
     assertEquals(
-      shouldRespond("ch-other", activeChannels, false, null, false),
+      shouldRespond("ch-other", activeChannels, false, null, false, false),
       false,
     );
   });
 
   await t.step("非 active channel で mention ありの場合は反応すること", () => {
     assertEquals(
-      shouldRespond("ch-other", activeChannels, false, null, true),
+      shouldRespond("ch-other", activeChannels, false, null, true, false),
       true,
-    );
-  });
-
-  await t.step("親チャンネルが active なスレッドでは反応すること", () => {
-    assertEquals(
-      shouldRespond("thread-1", activeChannels, true, "ch-active-1", false),
-      true,
-    );
-  });
-
-  await t.step("親チャンネルが非 active なスレッドでは無視すること", () => {
-    assertEquals(
-      shouldRespond("thread-1", activeChannels, true, "ch-other", false),
-      false,
     );
   });
 
   await t.step("スレッドで mention ありの場合は反応すること", () => {
     assertEquals(
-      shouldRespond("thread-1", activeChannels, true, "ch-other", true),
+      shouldRespond("thread-1", activeChannels, true, "ch-other", true, false),
       true,
     );
   });
 
   await t.step("親チャンネルが null のスレッドでは無視すること", () => {
     assertEquals(
-      shouldRespond("thread-1", activeChannels, true, null, false),
+      shouldRespond("thread-1", activeChannels, true, null, false, false),
       false,
     );
   });
@@ -115,7 +101,7 @@ Deno.test("shouldRespond", async (t) => {
     "activeChannelIds が空で mention ありの場合は反応すること",
     () => {
       assertEquals(
-        shouldRespond("ch-any", [], false, null, true),
+        shouldRespond("ch-any", [], false, null, true, false),
         true,
       );
     },
@@ -125,8 +111,85 @@ Deno.test("shouldRespond", async (t) => {
     "activeChannelIds が空で mention なしの場合は無視すること",
     () => {
       assertEquals(
-        shouldRespond("ch-any", [], false, null, false),
+        shouldRespond("ch-any", [], false, null, false, false),
         false,
+      );
+    },
+  );
+
+  // active channel スレッド無視
+  await t.step("active channel のスレッドは無視すること", () => {
+    assertEquals(
+      shouldRespond(
+        "thread-1",
+        activeChannels,
+        true,
+        "ch-active-1",
+        false,
+        false,
+      ),
+      false,
+    );
+  });
+
+  await t.step(
+    "active channel のスレッドは mention ありでも無視すること",
+    () => {
+      assertEquals(
+        shouldRespond(
+          "thread-1",
+          activeChannels,
+          true,
+          "ch-active-1",
+          true,
+          false,
+        ),
+        false,
+      );
+    },
+  );
+
+  // 他ユーザーメンション判定
+  await t.step(
+    "active channel で bot メンションなし + 他ユーザーメンションありの場合は無視すること",
+    () => {
+      assertEquals(
+        shouldRespond(
+          "ch-active-1",
+          activeChannels,
+          false,
+          null,
+          false,
+          true,
+        ),
+        false,
+      );
+    },
+  );
+
+  await t.step(
+    "active channel で bot メンション + 他ユーザーメンションありの場合は反応すること",
+    () => {
+      assertEquals(
+        shouldRespond(
+          "ch-active-1",
+          activeChannels,
+          false,
+          null,
+          true,
+          true,
+        ),
+        true,
+      );
+    },
+  );
+
+  await t.step(
+    "非 active channel では他ユーザーメンションに関係なく mention で反応すること",
+    () => {
+      assertEquals(
+        shouldRespond("ch-other", activeChannels, false, null, true, true),
+        true,
       );
     },
   );

--- a/bot/guard.test.ts
+++ b/bot/guard.test.ts
@@ -149,6 +149,23 @@ Deno.test("shouldRespond", async (t) => {
     },
   );
 
+  await t.step(
+    "active channel で bot メンションのみの場合は反応すること",
+    () => {
+      assertEquals(
+        shouldRespond(
+          "ch-active-1",
+          activeChannels,
+          false,
+          null,
+          true,
+          false,
+        ),
+        true,
+      );
+    },
+  );
+
   // 他ユーザーメンション判定
   await t.step(
     "active channel で bot メンションなし + 他ユーザーメンションありの場合は無視すること",

--- a/bot/guard.ts
+++ b/bot/guard.ts
@@ -36,9 +36,12 @@ export function isAuthorized(
 /**
  * メッセージに反応すべきか判定する。
  *
- * - activeChannelIds に含まれるチャンネル → 全メッセージ
- * - スレッドの親チャンネルが active → mention 不要
+ * - activeChannelIds に含まれるチャンネル → 原則全メッセージに反応
+ *   - ただしスレッドは全て無視
+ *   - bot へのメンションがなく他ユーザーへのメンションがある場合は無視
  * - それ以外 → bot mention 必須
+ *
+ * @param hasNonBotMentions - メッセージに bot 以外のユーザーメンションが含まれるか
  */
 export function shouldRespond(
   channelId: string,
@@ -46,12 +49,18 @@ export function shouldRespond(
   isThread: boolean,
   parentId: string | null,
   isMentioned: boolean,
+  hasNonBotMentions: boolean,
 ): boolean {
-  if (activeChannelIds.includes(channelId)) {
-    return true;
-  }
+  const isActive = activeChannelIds.includes(channelId) ||
+    (isThread && parentId !== null && activeChannelIds.includes(parentId));
 
-  if (isThread && parentId && activeChannelIds.includes(parentId)) {
+  if (isActive) {
+    if (isThread) {
+      return false;
+    }
+    if (!isMentioned && hasNonBotMentions) {
+      return false;
+    }
     return true;
   }
 

--- a/bot/guard.ts
+++ b/bot/guard.ts
@@ -41,7 +41,8 @@ export function isAuthorized(
  *   - bot へのメンションがなく他ユーザーへのメンションがある場合は無視
  * - それ以外 → bot mention 必須
  *
- * @param hasNonBotMentions - メッセージに bot 以外のユーザーメンションが含まれるか
+ * @param hasNonBotMentions - メッセージに bot 以外のユーザーメンションが含まれるか。
+ *   @everyone や @role は対象外（discord.js の mentions.users にはユーザー個別メンションのみ含まれる）。
  */
 export function shouldRespond(
   channelId: string,

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -292,6 +292,7 @@ export class DiscordBot {
     const isMentioned = this.client.user
       ? message.mentions.has(this.client.user)
       : false;
+    const hasNonBotMentions = message.mentions.users.some((u) => !u.bot);
     if (
       !shouldRespond(
         message.channelId,
@@ -299,6 +300,7 @@ export class DiscordBot {
         message.channel.isThread(),
         message.channel.isThread() ? message.channel.parentId : null,
         isMentioned,
+        hasNonBotMentions,
       )
     ) {
       return;


### PR DESCRIPTION
## Summary

Closes #44

- `shouldRespond` に `hasNonBotMentions` パラメータを追加し、active channel での反応条件を厳格化
- active channel のスレッドは全て無視
- bot メンションなし + 他ユーザーメンションありの投稿を無視
- 非 active channel は従来通り mention ベースで動作

## 変更ファイル

- `bot/guard.ts`: `shouldRespond` のロジック変更
- `bot/mod.ts`: `hasNonBotMentions` の算出と引数追加
- `bot/guard.test.ts`: 既存テスト修正 + 新規 5 ケース追加

## Test plan

- [x] `deno task test` 全テスト通過
- [x] `deno task check` 型チェック通過
- [x] Docker rebuild 後の実機確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)