### PR TITLE
fix: CronExecutor に CommandSpawner DI を追加

### DIFF
--- a/cron/executor.test.ts
+++ b/cron/executor.test.ts
@@ -62,6 +62,42 @@ function createMockSystemPromptStore(): SystemPromptStore {
   } as unknown as SystemPromptStore;
 }
 
+/** NDJSON ストリームを返すモック CommandSpawner。 */
+function mockSpawner(
+  lines: Record<string, unknown>[],
+  exitCode = 0,
+) {
+  return () => ({
+    stdout: new ReadableStream<Uint8Array>({
+      start(controller) {
+        const ndjson = lines.map((l) => JSON.stringify(l)).join("\n") + "\n";
+        controller.enqueue(new TextEncoder().encode(ndjson));
+        controller.close();
+      },
+    }),
+    stderr: Promise.resolve(""),
+    status: Promise.resolve({
+      success: exitCode === 0,
+      code: exitCode,
+      signal: null,
+    }),
+  });
+}
+
+/** askClaude が成功レスポンスを返す mockSpawner。 */
+function successSpawner(
+  result = "test result",
+  sessionId = "test-session",
+) {
+  return mockSpawner([{
+    type: "result",
+    subtype: "success",
+    result,
+    session_id: sessionId,
+    is_error: false,
+  }]);
+}
+
 const TEST_CONFIG = {
   maxTurns: 10,
   verbose: true,
@@ -85,6 +121,7 @@ Deno.test("CronExecutor", async (t) => {
       sessions,
       manager as never,
       systemPrompts,
+      mockSpawner([]),
     );
 
     const job: CronJobDef = {
@@ -119,6 +156,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        mockSpawner([]),
       );
 
       const job: CronJobDef = {
@@ -150,6 +188,7 @@ Deno.test("CronExecutor", async (t) => {
       sessions,
       manager as never,
       systemPrompts,
+      successSpawner(),
     );
 
     const job: CronJobDef = {
@@ -159,8 +198,6 @@ Deno.test("CronExecutor", async (t) => {
       channelId: "ch-approval",
     };
 
-    // runJob はチャンネル取得後に askClaude で失敗するが、
-    // setChannel は先に呼ばれる
     await executor.runJob(job);
     assertEquals(getChannelId(), "ch-approval");
   });
@@ -180,6 +217,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        successSpawner(),
       );
 
       const job: CronJobDef = {
@@ -188,7 +226,6 @@ Deno.test("CronExecutor", async (t) => {
         prompt: "hello",
       };
 
-      // askClaude が無いためエラーになるが、setChannel は呼ばれない
       await executor.runJob(job);
       assertEquals(getChannelId(), undefined);
     },
@@ -208,6 +245,7 @@ Deno.test("CronExecutor", async (t) => {
       sessions,
       manager as never,
       systemPrompts,
+      mockSpawner([]),
     );
 
     const jobs: CronJobDef[] = [
@@ -232,6 +270,7 @@ Deno.test("CronExecutor", async (t) => {
       sessions,
       manager as never,
       systemPrompts,
+      mockSpawner([]),
     );
 
     executor.start([
@@ -266,6 +305,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        successSpawner(),
       );
 
       const calledWith: string[] = [];
@@ -281,7 +321,6 @@ Deno.test("CronExecutor", async (t) => {
         once: true,
       };
 
-      // askClaude が無いためエラーになるが、once コールバックは finally で await される
       await executor.runJob(job);
       assertEquals(calledWith, ["once-job"]);
     },
@@ -302,6 +341,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        successSpawner(),
       );
 
       const calledWith: string[] = [];
@@ -336,6 +376,7 @@ Deno.test("CronExecutor", async (t) => {
       sessions,
       manager as never,
       systemPrompts,
+      mockSpawner([]),
     );
 
     const jobs: CronJobDef[] = [
@@ -368,6 +409,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        successSpawner(),
       );
 
       // setOnceCallback を呼ばない
@@ -402,6 +444,7 @@ Deno.test("CronExecutor", async (t) => {
         sessions,
         manager as never,
         systemPrompts,
+        successSpawner(),
       );
 
       let runningDuringCallback = false;

--- a/cron/executor.ts
+++ b/cron/executor.ts
@@ -10,7 +10,7 @@
 
 import type { Client, GuildTextBasedChannel } from "discord.js";
 import type { SDKResultMessage } from "@anthropic-ai/claude-agent-sdk";
-import { askClaude } from "../claude/mod.ts";
+import { askClaude, type CommandSpawner } from "../claude/mod.ts";
 import type { ClaudeConfig } from "../config.ts";
 import type { SessionStore } from "../session/mod.ts";
 import type { ApprovalManager } from "../approval/manager.ts";
@@ -40,6 +40,7 @@ export class CronExecutor {
     private readonly sessions: SessionStore,
     private readonly approvalManager: ApprovalManager,
     private readonly systemPrompts: SystemPromptStore,
+    private readonly spawner?: CommandSpawner,
   ) {
     this.scheduler = new CronScheduler((job) => this.runJob(job));
   }
@@ -154,6 +155,7 @@ export class CronExecutor {
         config: jobConfig,
         signal: AbortSignal.timeout(timeout),
         appendSystemPrompt,
+        spawner: this.spawner,
       });
 
       let resultEvent: SDKResultMessage | undefined;


### PR DESCRIPTION
Closes #48

## Summary
- `CronExecutor` のコンストラクタに optional な `CommandSpawner` パラメータを追加
- `runJob()` 内の `askClaude()` 呼び出しに `spawner` を透過的に渡す
- テストに `mockSpawner()` / `successSpawner()` ヘルパーを追加し、全テストケースで注入

## 背景
テスト実行時に `askClaude()` が実際の claude CLI をプロセス spawn していた。`claude/mod.test.ts` や `voice/adapter.test.ts` では既に `mockSpawner` パターンで解決済みだったが、`CronExecutor` だけ未対応だった。

## Test plan
- [x] `deno task test` で全テスト通過（34 passed, 0 failed）
- [x] テスト実行中に余分な claude プロセスが spawn されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)