### PR TITLE
refactor: cron/loader.ts のバリデーションを ajv に移行

### DIFF
--- a/cron/loader.test.ts
+++ b/cron/loader.test.ts
@@ -152,6 +152,19 @@ Deno.test("validateCronJob", async (t) => {
     assertEquals(job.once, false);
   });
 
+  await t.step("channelId が string でも number でもない場合はエラーになること", () => {
+    assertThrows(
+      () =>
+        validateCronJob(
+          { schedule: "0 9 * * *", channelId: true },
+          "prompt",
+          "test.md",
+        ),
+      Error,
+      '"channelId" must be a string or number',
+    );
+  });
+
   await t.step("once が boolean でない場合はエラーになること", () => {
     assertThrows(
       () =>

--- a/cron/loader.ts
+++ b/cron/loader.ts
@@ -10,6 +10,7 @@
 import { join } from "jsr:@std/path@^1/join";
 import { extract } from "@std/front-matter/yaml";
 import Ajv from "ajv";
+import type { ErrorObject, ValidateFunction } from "ajv";
 import { createLogger } from "../logger.ts";
 import { parseCronExpression } from "./match.ts";
 import type { CronJobDef } from "./types.ts";
@@ -43,6 +44,8 @@ const cronExpressionValidate = Object.assign(
     } catch (e) {
       cronExpressionValidate.errors = [{
         keyword: "cronExpression",
+        instancePath: "",
+        schemaPath: "#/cronExpression",
         message: `invalid cron expression: ${
           e instanceof Error ? e.message : String(e)
         }`,
@@ -51,7 +54,7 @@ const cronExpressionValidate = Object.assign(
       return false;
     }
   },
-  { errors: [] as { keyword: string; message: string; params: unknown }[] },
+  { errors: [] as ErrorObject[] },
 );
 
 ajv.addKeyword({
@@ -60,8 +63,6 @@ ajv.addKeyword({
   validate: cronExpressionValidate,
   errors: true,
 });
-
-import type { ValidateFunction } from "ajv";
 
 const validateFrontMatter: ValidateFunction<CronFrontMatter> = ajv.compile<CronFrontMatter>({
   type: "object",
@@ -126,6 +127,10 @@ export function validateCronJob(
       errors.push('"schedule" is required and must be a non-empty string');
     } else if (err.keyword === "type") {
       const field = err.instancePath.slice(1);
+      // oneOf 配下の type エラーは親の oneOf エラーで処理するためスキップ
+      if (field === "channelId") {
+        continue;
+      }
       const expected = err.params.type;
       errors.push(`"${field}" must be a ${expected}`);
     } else if (err.keyword === "oneOf" && err.instancePath === "/channelId") {

--- a/cron/loader.ts
+++ b/cron/loader.ts
@@ -9,11 +9,73 @@
 
 import { join } from "jsr:@std/path@^1/join";
 import { extract } from "@std/front-matter/yaml";
+import Ajv from "ajv";
 import { createLogger } from "../logger.ts";
 import { parseCronExpression } from "./match.ts";
 import type { CronJobDef } from "./types.ts";
 
 const log = createLogger("cron-loader");
+
+/**
+ * フロントマター用 JSON Schema。
+ *
+ * ajv の `compile()` で型ガード関数を生成し、
+ * バリデーション通過後は `as` キャスト不要で型安全にアクセスできる。
+ */
+interface CronFrontMatter {
+  schedule: string;
+  channelId?: string | number;
+  maxTurns?: number;
+  timeout?: number;
+  resumeSession?: boolean;
+  once?: boolean;
+}
+
+// deno の npm 互換レイヤーでは CJS default export のコンストラクタ型が解決できない
+// @ts-expect-error: Ajv CJS default export
+const ajv = new Ajv({ allErrors: true });
+
+const cronExpressionValidate = Object.assign(
+  (_schema: boolean, data: string): boolean => {
+    try {
+      parseCronExpression(data);
+      return true;
+    } catch (e) {
+      cronExpressionValidate.errors = [{
+        keyword: "cronExpression",
+        message: `invalid cron expression: ${
+          e instanceof Error ? e.message : String(e)
+        }`,
+        params: { value: data },
+      }];
+      return false;
+    }
+  },
+  { errors: [] as { keyword: string; message: string; params: unknown }[] },
+);
+
+ajv.addKeyword({
+  keyword: "cronExpression",
+  type: "string",
+  validate: cronExpressionValidate,
+  errors: true,
+});
+
+import type { ValidateFunction } from "ajv";
+
+const validateFrontMatter: ValidateFunction<CronFrontMatter> = ajv.compile<CronFrontMatter>({
+  type: "object",
+  properties: {
+    schedule: { type: "string", minLength: 1, cronExpression: true },
+    channelId: { oneOf: [{ type: "string" }, { type: "number" }] },
+    maxTurns: { type: "number" },
+    timeout: { type: "number" },
+    resumeSession: { type: "boolean" },
+    once: { type: "boolean" },
+  },
+  required: ["schedule"],
+  additionalProperties: true,
+});
 
 /**
  * パース済みのフロントマターと本文を CronJobDef にバリデーションする。
@@ -29,69 +91,55 @@ export function validateCronJob(
   filename: string,
 ): CronJobDef {
   const name = filename.replace(/\.md$/, "");
+
+  if (validateFrontMatter(meta)) {
+    // 型ガード通過: meta は CronFrontMatter に narrowing 済み
+    if (!body) {
+      throw new Error(`${filename}: prompt body is empty`);
+    }
+
+    return {
+      name,
+      schedule: meta.schedule,
+      prompt: body,
+      channelId: meta.channelId != null
+        ? String(meta.channelId)
+        : undefined,
+      maxTurns: meta.maxTurns,
+      timeout: meta.timeout,
+      resumeSession: meta.resumeSession ?? false,
+      once: meta.once ?? false,
+    };
+  }
+
+  // バリデーション失敗: エラーメッセージを収集
   const errors: string[] = [];
 
-  // 必須 string フィールド
-  if (typeof meta.schedule !== "string" || (meta.schedule as string) === "") {
-    errors.push('"schedule" is required and must be a non-empty string');
+  for (const err of validateFrontMatter.errors ?? []) {
+    if (err.keyword === "cronExpression") {
+      errors.push(err.message ?? "invalid cron expression");
+    } else if (err.keyword === "required") {
+      errors.push(
+        `"${err.params.missingProperty}" is required and must be a non-empty string`,
+      );
+    } else if (err.keyword === "minLength" && err.instancePath === "/schedule") {
+      errors.push('"schedule" is required and must be a non-empty string');
+    } else if (err.keyword === "type") {
+      const field = err.instancePath.slice(1);
+      const expected = err.params.type;
+      errors.push(`"${field}" must be a ${expected}`);
+    } else if (err.keyword === "oneOf" && err.instancePath === "/channelId") {
+      errors.push('"channelId" must be a string or number');
+    } else {
+      errors.push(err.message ?? "validation error");
+    }
   }
 
-  // channelId はオプション。指定時は数値でも文字列でも許容
-  if (
-    meta.channelId !== undefined && meta.channelId !== null &&
-    typeof meta.channelId !== "string" && typeof meta.channelId !== "number"
-  ) {
-    errors.push('"channelId" must be a string or number');
-  }
-
-  // オプション number
-  if (meta.maxTurns !== undefined && typeof meta.maxTurns !== "number") {
-    errors.push('"maxTurns" must be a number');
-  }
-  if (meta.timeout !== undefined && typeof meta.timeout !== "number") {
-    errors.push('"timeout" must be a number');
-  }
-  if (
-    meta.resumeSession !== undefined && typeof meta.resumeSession !== "boolean"
-  ) {
-    errors.push('"resumeSession" must be a boolean');
-  }
-  if (meta.once !== undefined && typeof meta.once !== "boolean") {
-    errors.push('"once" must be a boolean');
-  }
-
-  // プロンプト（本文）が空でないこと
   if (!body) {
     errors.push("prompt body is empty");
   }
 
-  // cron 式のバリデーション
-  if (typeof meta.schedule === "string" && meta.schedule !== "") {
-    try {
-      parseCronExpression(meta.schedule as string);
-    } catch (e) {
-      errors.push(
-        `invalid cron expression: ${
-          e instanceof Error ? e.message : String(e)
-        }`,
-      );
-    }
-  }
-
-  if (errors.length > 0) {
-    throw new Error(`${filename}: ${errors.join("; ")}`);
-  }
-
-  return {
-    name,
-    schedule: meta.schedule as string,
-    prompt: body,
-    channelId: meta.channelId != null ? String(meta.channelId) : undefined,
-    maxTurns: meta.maxTurns as number | undefined,
-    timeout: meta.timeout as number | undefined,
-    resumeSession: (meta.resumeSession as boolean | undefined) ?? false,
-    once: (meta.once as boolean | undefined) ?? false,
-  };
+  throw new Error(`${filename}: ${errors.join("; ")}`);
 }
 
 /**

--- a/deno.json
+++ b/deno.json
@@ -19,6 +19,7 @@
     "discord.js": "npm:discord.js@^14.26.2",
     "opusscript": "npm:opusscript@0.1.1",
     "@std/assert": "jsr:@std/assert@^1.0.19",
+    "ajv": "npm:ajv@^8.18.0",
     "@std/dotenv": "jsr:@std/dotenv@^0.225.6",
     "@std/path": "jsr:@std/path@^1.1.4",
     "@std/streams": "jsr:@std/streams@^1.0.17"

--- a/deno.lock
+++ b/deno.lock
@@ -6,18 +6,22 @@
     "jsr:@openai/openai@^6.33.0": "6.33.0",
     "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/bytes@^1.0.6": "1.0.6",
+    "jsr:@std/collections@^1.1.3": "1.1.6",
     "jsr:@std/dotenv@~0.225.6": "0.225.6",
     "jsr:@std/front-matter@^1.0.9": "1.0.9",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/streams@^1.0.17": "1.0.17",
+    "jsr:@std/toml@^1.0.3": "1.0.11",
     "jsr:@std/yaml@^1.0.5": "1.0.12",
-    "npm:@anthropic-ai/claude-agent-sdk@~0.2.92": "0.2.92_zod@4.3.6",
+    "npm:@anthropic-ai/claude-agent-sdk@~0.2.92": "0.2.92_zod@3.25.76",
     "npm:@discordjs/voice@0.19.2": "0.19.2_opusscript@0.1.1",
     "npm:@snazzah/davey@~0.1.11": "0.1.11",
+    "npm:ajv@^8.18.0": "8.18.0",
     "npm:discord.js@^14.26.2": "14.26.2",
-    "npm:opusscript@0.1.1": "0.1.1"
+    "npm:opusscript@0.1.1": "0.1.1",
+    "npm:zod@3": "3.25.76"
   },
   "jsr": {
     "@aireone/deno-lint-curly@0.2.0": {
@@ -27,7 +31,10 @@
       "integrity": "6e608e50bb13fd0933e86fda95d31c1ff57d1c8774ed585d6a8b8fc1bdd82c82"
     },
     "@openai/openai@6.33.0": {
-      "integrity": "292fec0ff0fd8b04f25e0ccbee8a06895b423abfb5113b9076e4ae39b4a18721"
+      "integrity": "292fec0ff0fd8b04f25e0ccbee8a06895b423abfb5113b9076e4ae39b4a18721",
+      "dependencies": [
+        "npm:zod"
+      ]
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -38,12 +45,16 @@
     "@std/bytes@1.0.6": {
       "integrity": "f6ac6adbd8ccd99314045f5703e23af0a68d7f7e58364b47d2c7f408aeb5820a"
     },
+    "@std/collections@1.1.6": {
+      "integrity": "b458160ce65ea5ad35da05d0a5cbee4b583677c8b443a10d7beb0c4ac63f2baa"
+    },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
     },
     "@std/front-matter@1.0.9": {
       "integrity": "ee6201d06674cbef137dda2252f62477450b48249e7d8d9ab57a30f85ff6f051",
       "dependencies": [
+        "jsr:@std/toml",
         "jsr:@std/yaml"
       ]
     },
@@ -62,12 +73,18 @@
         "jsr:@std/bytes"
       ]
     },
+    "@std/toml@1.0.11": {
+      "integrity": "e084988b872ca4bad6aedfb7350f6eeed0e8ba88e9ee5e1590621c5b5bb8f715",
+      "dependencies": [
+        "jsr:@std/collections"
+      ]
+    },
     "@std/yaml@1.0.12": {
       "integrity": "7deabca4545bcedd07c5f69ea53acea71b8b4c67562f224e17b90d75944cb20c"
     }
   },
   "npm": {
-    "@anthropic-ai/claude-agent-sdk@0.2.92_zod@4.3.6": {
+    "@anthropic-ai/claude-agent-sdk@0.2.92_zod@3.25.76": {
       "integrity": "sha512-loYyxVUC5gBwHjGi9Fv0b84mduJTp9Z3Pum+y/7IVQDb4NynKfVQl6l4VeDKZaW+1QTQtd25tY4hwUznD7Krqw==",
       "dependencies": [
         "@anthropic-ai/sdk",
@@ -86,7 +103,7 @@
         "@img/sharp-win32-x64"
       ]
     },
-    "@anthropic-ai/sdk@0.80.0_zod@4.3.6": {
+    "@anthropic-ai/sdk@0.80.0_zod@3.25.76": {
       "integrity": "sha512-WeXLn7zNVk3yjeshn+xZHvld6AoFUOR3Sep6pSoHho5YbSi6HwcirqgPA5ccFuW8QTVJAAU7N8uQQC6Wa9TG+g==",
       "dependencies": [
         "json-schema-to-ts",
@@ -295,7 +312,7 @@
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@modelcontextprotocol/sdk@1.29.0_zod@4.3.6_hono@4.12.10_ajv@8.18.0_express@5.2.1": {
+    "@modelcontextprotocol/sdk@1.29.0_zod@3.25.76_hono@4.12.10_ajv@8.18.0_express@5.2.1": {
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "dependencies": [
         "@hono/node-server",
@@ -994,14 +1011,14 @@
     "ws@8.20.0": {
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
-    "zod-to-json-schema@3.25.2_zod@4.3.6": {
+    "zod-to-json-schema@3.25.2_zod@3.25.76": {
       "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dependencies": [
         "zod"
       ]
     },
-    "zod@4.3.6": {
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="
+    "zod@3.25.76": {
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="
     }
   },
   "workspace": {
@@ -1016,6 +1033,7 @@
       "npm:@anthropic-ai/claude-agent-sdk@~0.2.92",
       "npm:@discordjs/voice@0.19.2",
       "npm:@snazzah/davey@~0.1.11",
+      "npm:ajv@^8.18.0",
       "npm:discord.js@^14.26.2",
       "npm:opusscript@0.1.1"
     ]


### PR DESCRIPTION
## Summary

- `cron/loader.ts` の手動 `typeof` チェック + `as` 型アサーションを ajv JSON Schema バリデーションに置換
- cron 式の検証をカスタムキーワード `cronExpression` として ajv に統合
- `ValidateFunction<CronFrontMatter>` 型ガードにより `as` キャストを全排除
- `channelId` の `oneOf` 配下 `type` エラー重複を防止、テストケース追加

Closes #50

## Test plan

- [x] 既存の `cron/loader.test.ts` が全テスト通過（新規 channelId 型エラーケース含む）
- [x] `deno check` 型チェック通過
- [x] `deno lint` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)