### PR TITLE
fix: whisper API の無音時ハルシネーション対策

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,8 @@ AUTHORIZED_USER_ID=
 # AUTO_LEAVE_MS=600000
 # 発話デバウンス待機時間 ms（デフォルト: 500）
 # SPEECH_DEBOUNCE_MS=500
+# no_speech_prob 閾値。全セグメントがこの値以上なら無音と判定（デフォルト: 0.6）
+# NO_SPEECH_PROB_THRESHOLD=0.6
 # 通知トーンの有効/無効（デフォルト: true）
 # NOTIFICATION_TONE=true
 # auto-join: false=無効, true=全VC, カンマ区切り=指定VC IDのみ（デフォルト: false）

--- a/bot/guard.test.ts
+++ b/bot/guard.test.ts
@@ -26,6 +26,7 @@ const baseConfig: Config = {
     interruptRms: 500,
     autoLeaveMs: 600000,
     speechDebounceMs: 500,
+    noSpeechProbThreshold: 0.6,
     notificationTone: true,
     autoJoinVc: false,
   },

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -81,7 +81,10 @@ export class DiscordBot {
 
     // ボイス機能の初期化。
     if (config.voice.enabled) {
-      const stt = new WhisperStt({ baseUrl: config.voice.whisperUrl });
+      const stt = new WhisperStt({
+        baseUrl: config.voice.whisperUrl,
+        noSpeechProbThreshold: config.voice.noSpeechProbThreshold,
+      });
       const tts = new OpenAiTts({
         baseUrl: config.voice.ttsUrl,
         apiKey: config.voice.ttsApiKey,

--- a/config.ts
+++ b/config.ts
@@ -49,6 +49,8 @@ export interface VoiceConfig {
   autoLeaveMs: number;
   /** 発話デバウンス待機時間（ミリ秒）。 */
   speechDebounceMs: number;
+  /** no_speech_prob 閾値。全セグメントがこの値以上なら無音と判定。 */
+  noSpeechProbThreshold: number;
   /** 通知トーン（処理中・エラー）の有効/無効。 */
   notificationTone: boolean;
   /** auto-join: false=無効, true=全VC, string[]=指定VC IDのみ。 */
@@ -140,6 +142,9 @@ export function loadConfig(): Config {
       interruptRms: Number(Deno.env.get("INTERRUPT_RMS") ?? "500"),
       autoLeaveMs: Number(Deno.env.get("AUTO_LEAVE_MS") ?? "600000"),
       speechDebounceMs: Number(Deno.env.get("SPEECH_DEBOUNCE_MS") ?? "500"),
+      noSpeechProbThreshold: Number(
+        Deno.env.get("NO_SPEECH_PROB_THRESHOLD") ?? "0.6",
+      ),
       notificationTone:
         (Deno.env.get("NOTIFICATION_TONE") ?? "true") === "true",
       autoJoinVc: parseAutoJoinVc(Deno.env.get("AUTO_JOIN_VC")),

--- a/voice/stt.ts
+++ b/voice/stt.ts
@@ -43,6 +43,13 @@ export interface WhisperSttConfig {
    * whisper.cpp サーバーのベース URL（例: `http://localhost:8178`）。
    */
   baseUrl: string;
+
+  /**
+   * no_speech_prob の閾値。
+   * verbose_json 形式で返却される各セグメントの no_speech_prob が
+   * 全セグメントでこの値以上の場合、音声なしと判定する。
+   */
+  noSpeechProbThreshold: number;
 }
 
 /**
@@ -53,9 +60,11 @@ export interface WhisperSttConfig {
  */
 export class WhisperStt implements SpeechToText {
   private readonly baseUrl: string;
+  private readonly noSpeechProbThreshold: number;
 
   constructor(config: WhisperSttConfig) {
     this.baseUrl = config.baseUrl;
+    this.noSpeechProbThreshold = config.noSpeechProbThreshold;
   }
 
   /**
@@ -76,7 +85,7 @@ export class WhisperStt implements SpeechToText {
       new Blob([wavBytes], { type: "audio/wav" }),
       "audio.wav",
     );
-    form.append("response_format", "json");
+    form.append("response_format", "verbose_json");
     form.append("suppress_non_speech_tokens", "true");
 
     const res = await fetch(`${this.baseUrl}/inference`, {
@@ -91,6 +100,22 @@ export class WhisperStt implements SpeechToText {
     }
 
     const data = await res.json();
+
+    // 全セグメントの no_speech_prob が閾値以上なら無音と判定する。
+    const segments: { no_speech_prob?: number }[] = data.segments ?? [];
+    if (
+      segments.length > 0 &&
+      segments.every((s) =>
+        (s.no_speech_prob ?? 0) >= this.noSpeechProbThreshold
+      )
+    ) {
+      log.debug(
+        "all segments exceeded no_speech_prob threshold:",
+        segments.map((s) => s.no_speech_prob),
+      );
+      return "";
+    }
+
     const raw: string = (data.text ?? "").trim();
 
     // 非音声トークンを除去してクリーンな文字起こし結果を返す。


### PR DESCRIPTION
## Summary

- whisper API の `response_format` を `verbose_json` に変更し、セグメント毎の `no_speech_prob` を取得
- 全セグメントの `no_speech_prob` が閾値以上の場合、無音と判定して空文字を返す
- 閾値は `NO_SPEECH_PROB_THRESHOLD` 環境変数で外部指定可能（デフォルト: 0.6）

Closes #52

## Test plan

- [ ] 無音状態で whisper にリクエストを送り、ハルシネーションが抑制されることを確認
- [ ] 正常な発話が無音判定されないことを確認
- [ ] `NO_SPEECH_PROB_THRESHOLD` 環境変数で閾値が変更できることを確認
- [ ] `deno task check` / `deno task test` が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)