### PR TITLE
feat: bot の応答を発言したユーザ宛のメンション付きにする

### DIFF
--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -405,6 +405,20 @@ export class DiscordBot {
     const progress = createProgressReporter(channel);
     let downloadedImages: DownloadedImage[] = [];
 
+    // 応答は発言者宛にする: 最初の 1 通だけ先頭にメンションを付け、以降の
+    // チャンクは通常送信する（毎チャンクで発言者に通知が飛ぶのを防ぐ）。
+    // メンションは分割前のテキスト先頭に付けてから splitMessage に渡す。
+    // 先頭チャンクが上限ぎりぎりでもメンション分が溢れないようにするため。
+    const mention = `<@${message.author.id}> `;
+    let mentioned = false;
+    const sendChunks = async (text: string): Promise<void> => {
+      const body = mentioned ? text : mention + text;
+      mentioned = true;
+      for (const chunk of splitMessage(body)) {
+        await channel.send(chunk);
+      }
+    };
+
     try {
       // 画像添付をダウンロード（画像フィルタは downloadImageAttachments 内で行う）
       if (hasAttachments) {
@@ -473,9 +487,7 @@ export class DiscordBot {
           textBuffer = "";
           if (text) {
             hasStreamedText = true;
-            for (const chunk of splitMessage(text)) {
-              await channel.send(chunk);
-            }
+            await sendChunks(text);
           }
           return;
         }
@@ -498,9 +510,7 @@ export class DiscordBot {
           return;
         }
         hasStreamedText = true;
-        for (const chunk of splitMessage(send)) {
-          await channel.send(chunk);
-        }
+        await sendChunks(send);
       };
 
       for await (const event of stream) {
@@ -534,15 +544,14 @@ export class DiscordBot {
         if (!resultEvent) {
           throw new Error("claude stream ended without result event");
         }
-        for (const chunk of splitMessage(extractResultText(resultEvent))) {
-          await channel.send(chunk);
-        }
+        await sendChunks(extractResultText(resultEvent));
       }
     } catch (error: unknown) {
       // logger は Error の stack を自動で展開する。
       log.error("failed to process message:", error);
       const errMsg = getErrorMessage(error);
-      await channel.send(`Error: ${errMsg}`).catch(() => {});
+      // エラーもまだ何も送っていなければ発言者宛にする（content 送出済みなら継続扱い）。
+      await sendChunks(`Error: ${errMsg}`).catch(() => {});
     } finally {
       if (downloadedImages.length > 0) {
         await cleanupImageFiles(downloadedImages);


### PR DESCRIPTION
## 概要

bot のテキスト応答を、発言したユーザ宛であることが明示されるように変更する。

これまで `bot/mod.ts` の `onMessage` では応答を `channel.send()` で誰にも宛てずにチャンネルへ投稿していた。発言者宛であることを明示するため、応答の最初の 1 通の先頭に発言者へのメンション (`<@userId>`) を付与する。

## 変更点

- `sendChunks` ヘルパを `try` の外に定義し、以下の全送信経路をこれ経由に統一:
  - ストリーミングの強制フラッシュ / 文境界フラッシュ
  - 非ストリーミング時の `extractResultText` フォールバック
  - `catch` 節のエラー通知
- メンションは **最初の 1 通のみ** に付け、以降のチャンクは通常送信する（毎チャンクで発言者へ通知が飛ぶのを防ぐ）。
- メンションは分割前テキストの先頭に付けてから `splitMessage` に渡すため、先頭チャンクが文字数上限ぎりぎりでもメンション分で 2000 字上限を超えない。

## 補足

- エラー通知も `sendChunks` 経由にしたため、本文を 1 通も送る前に失敗した場合はエラーが発言者宛に飛ぶ。本文送出後のエラーはメンション無しの継続扱いになる。
- 対象はテキストチャットの `onMessage` のみ。cron（発火ユーザ無し）と VC（音声経路）は対象外。
- メンションが実際に ping するには discord.js の `allowedMentions` が content 由来のメンションを許可している必要がある。現状この `Client` は `allowedMentions` 未設定のためデフォルト（content 内メンションをパースして ping）が効く。

## 確認

- `deno task check` 通過
- `deno task lint` 通過
- `deno task test` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)