### PR TITLE
fix: 存在しない session ID で resume した際に新規セッションで再試行する

### DIFF
--- a/claude/mod.test.ts
+++ b/claude/mod.test.ts
@@ -9,6 +9,7 @@ import {
   buildQueryOptions,
   extractResultText,
   extractTopLevelTextDelta,
+  isSessionNotFoundError,
   normalizeEffort,
   type QueryFn,
 } from "./mod.ts";
@@ -50,6 +51,55 @@ function throwingQueryFn(message: string): QueryFn {
   return (_params: Parameters<QueryFn>[0]): ReturnType<QueryFn> => {
     throw new Error(message);
   };
+}
+
+/**
+ * 呼び出し毎に挙動を切り替えるモック queryFn を生成する。
+ *
+ * 各呼び出しの `behavior` は以下のいずれか:
+ *   - `{ throw }`            : 起動時に同期 throw (何も yield しない)
+ *   - `{ messages }`         : messages を順に yield
+ *   - `{ messages, throw }`  : messages を yield した後に throw
+ *
+ * 各呼び出しの `resume` を `captureResume` で記録できる。再試行時に resume が
+ * 外れていることの検証に使う。
+ */
+function sequencedQueryFn(
+  behaviors: Array<{ messages?: SDKMessage[]; throw?: string }>,
+  captureResume?: (resume: string | undefined, callIndex: number) => void,
+): QueryFn {
+  let call = 0;
+  return (params: Parameters<QueryFn>[0]): ReturnType<QueryFn> => {
+    const idx = call++;
+    captureResume?.(params.options?.resume, idx);
+    const behavior = behaviors[idx];
+    if (behavior === undefined) {
+      throw new Error(`unexpected query call #${idx}`);
+    }
+    const { messages = [], throw: throwMessage } = behavior;
+    async function* gen(): AsyncGenerator<SDKMessage> {
+      for (const m of messages) {
+        yield m;
+      }
+      if (throwMessage !== undefined) {
+        throw new Error(throwMessage);
+      }
+    }
+    return gen() as unknown as ReturnType<QueryFn>;
+  };
+}
+
+const SESSION_NOT_FOUND =
+  "Claude Code returned an error result: No conversation found with session ID: stale-session";
+
+function resultMessage(sessionId: string): SDKMessage {
+  return {
+    type: "result",
+    subtype: "success",
+    result: "ok",
+    session_id: sessionId,
+    is_error: false,
+  } as SDKMessage;
 }
 
 Deno.test("normalizeEffort", async (t) => {
@@ -230,6 +280,152 @@ Deno.test("askClaude", async (t) => {
       Error,
       "claude query failed: boom",
     );
+  });
+
+  await t.step(
+    "resume 先セッションが存在しない場合は resume を外して新規セッションで再試行すること",
+    async () => {
+      const resumes: Array<string | undefined> = [];
+      const queryFn = sequencedQueryFn(
+        [
+          { throw: SESSION_NOT_FOUND },
+          { messages: [resultMessage("new-session")] },
+        ],
+        (resume) => resumes.push(resume),
+      );
+
+      const collected: SDKMessage[] = [];
+      for await (
+        const event of askClaude("hello", {
+          config: baseConfig,
+          sessionId: "stale-session",
+          queryFn,
+        })
+      ) {
+        collected.push(event);
+      }
+
+      // 1 回目は resume あり、2 回目 (再試行) は resume 無し
+      assertEquals(resumes, ["stale-session", undefined]);
+      // 再試行側の result イベントが yield されること
+      assertEquals(collected.length, 1);
+      assertEquals(collected[0].type, "result");
+    },
+  );
+
+  await t.step(
+    "再試行は 1 回限りで、再び失敗すれば throw すること",
+    async () => {
+      let calls = 0;
+      const queryFn = sequencedQueryFn(
+        [
+          { throw: SESSION_NOT_FOUND },
+          { throw: SESSION_NOT_FOUND },
+        ],
+        () => calls++,
+      );
+
+      await assertRejects(
+        async () => {
+          for await (
+            const _ of askClaude("hello", {
+              config: baseConfig,
+              sessionId: "stale-session",
+              queryFn,
+            })
+          ) {
+            void _;
+          }
+        },
+        Error,
+        "claude query failed:",
+      );
+      // 初回 + 再試行の 2 回で打ち切られること
+      assertEquals(calls, 2);
+    },
+  );
+
+  await t.step(
+    "session-not-found 以外のエラーでは再試行しないこと",
+    async () => {
+      let calls = 0;
+      const queryFn = sequencedQueryFn([{ throw: "boom" }], () => calls++);
+
+      await assertRejects(
+        async () => {
+          for await (
+            const _ of askClaude("hello", {
+              config: baseConfig,
+              sessionId: "stale-session",
+              queryFn,
+            })
+          ) {
+            void _;
+          }
+        },
+        Error,
+        "claude query failed: boom",
+      );
+      assertEquals(calls, 1);
+    },
+  );
+
+  await t.step(
+    "既に yield 済みなら session-not-found でも再試行しないこと",
+    async () => {
+      let calls = 0;
+      const queryFn = sequencedQueryFn(
+        [
+          {
+            messages: [
+              {
+                type: "system",
+                subtype: "init",
+                session_id: "s",
+              } as SDKMessage,
+            ],
+            throw: SESSION_NOT_FOUND,
+          },
+        ],
+        () => calls++,
+      );
+
+      const collected: SDKMessage[] = [];
+      await assertRejects(
+        async () => {
+          for await (
+            const event of askClaude("hello", {
+              config: baseConfig,
+              sessionId: "stale-session",
+              queryFn,
+            })
+          ) {
+            collected.push(event);
+          }
+        },
+        Error,
+        "claude query failed:",
+      );
+      // yield 済みのイベントは消費側に届いた上で throw、再試行はしない
+      assertEquals(collected.length, 1);
+      assertEquals(calls, 1);
+    },
+  );
+});
+
+Deno.test("isSessionNotFoundError", async (t) => {
+  await t.step("session 不在メッセージを検出すること", () => {
+    assertEquals(
+      isSessionNotFoundError(
+        "Claude Code returned an error result: No conversation found with session ID: abc",
+      ),
+      true,
+    );
+  });
+
+  await t.step("無関係なエラーは false になること", () => {
+    assertEquals(isSessionNotFoundError("boom"), false);
+    assertEquals(isSessionNotFoundError("rate limit exceeded"), false);
   });
 });
 

--- a/claude/mod.ts
+++ b/claude/mod.ts
@@ -61,6 +61,20 @@ export interface ClaudeCallOptions {
 }
 
 /**
+ * エラーメッセージが「resume 先のセッションが存在しない」ことを示すか判定する。
+ *
+ * `resume` に渡した session ID が Claude 側の会話履歴に無い場合、SDK は
+ * `No conversation found with session ID: <uuid>` というメッセージで throw する。
+ * KV に古い session ID が残ったまま該当セッションが消えている状況で発生する。
+ *
+ * この判定が真のとき、{@link askClaude} は resume を外して新規セッションで
+ * 一度だけやり直す。
+ */
+export function isSessionNotFoundError(message: string): boolean {
+  return message.includes("No conversation found with session ID");
+}
+
+/**
  * effort 値を検証し、SDK 対応の値のみ返す。
  *
  * 非対応の値は警告ログを出して `undefined` を返す。
@@ -201,26 +215,65 @@ export async function* askClaude(
     }
   }
 
-  const queryOptions = buildQueryOptions(config, callOpts, abortController);
+  // resume 先のセッションが存在しない場合、resume を外して新規セッションで
+  // 一度だけやり直す。stale な session ID が KV に残ったまま Claude 側の会話が
+  // 消えているケースを救済する (新しい session_id は呼び出し元が result イベント
+  // から保存し直す)。
+  let sessionId = callOpts.sessionId;
+  let retriedWithoutSession = false;
 
-  log.debug("starting query:", {
-    sessionId: callOpts.sessionId,
-    model: callOpts.model,
-    effort: queryOptions.effort,
-  });
+  while (true) {
+    const queryOptions = buildQueryOptions(
+      config,
+      { ...callOpts, sessionId },
+      abortController,
+    );
 
-  // エラー時の診断のため、受信したイベント type 列と最後のイベントを保持する。
-  const eventTypes: string[] = [];
-  let lastEvent: SDKMessage | undefined;
+    log.debug("starting query:", {
+      sessionId,
+      model: callOpts.model,
+      effort: queryOptions.effort,
+    });
 
-  try {
-    for await (const message of queryFn({ prompt, options: queryOptions })) {
-      eventTypes.push(message.type);
-      lastEvent = message;
-      yield message;
+    // エラー時の診断のため、受信したイベント type 列と最後のイベントを保持する。
+    const eventTypes: string[] = [];
+    let lastEvent: SDKMessage | undefined;
+    let caught: unknown;
+
+    try {
+      for await (const message of queryFn({ prompt, options: queryOptions })) {
+        eventTypes.push(message.type);
+        lastEvent = message;
+        yield message;
+      }
+    } catch (error: unknown) {
+      caught = error;
     }
-  } catch (error: unknown) {
-    const reason = getErrorMessage(error);
+
+    if (caught === undefined) {
+      log.info("claude stream completed");
+      return;
+    }
+
+    const reason = getErrorMessage(caught);
+
+    // resume 先のセッションが見つからない場合のみ、新規セッションで再試行する。
+    // このエラーは query 起動時 (まだ何も yield していない時点) に発生するため、
+    // 既に何か yield 済みなら再試行しない (下流の二重出力を防ぐ)。
+    if (
+      sessionId !== undefined &&
+      !retriedWithoutSession &&
+      eventTypes.length === 0 &&
+      isSessionNotFoundError(reason)
+    ) {
+      log.warn(
+        `session ${sessionId} not found, retrying with a new session`,
+      );
+      sessionId = undefined;
+      retriedWithoutSession = true;
+      continue;
+    }
+
     const parts: string[] = [
       `claude query failed: ${reason}`,
       eventTypes.length > 0
@@ -233,6 +286,4 @@ export async function* askClaude(
     log.error(parts.join("\n"));
     throw new Error(`claude query failed: ${reason}`);
   }
-
-  log.info("claude stream completed");
 }


### PR DESCRIPTION
## 概要

KV に古い `session_id` が残ったまま Claude 側の会話が消えている状態で `resume` すると、Agent SDK が次のエラーで throw し、ユーザーにはエラーだけが返っていた。

```
Error: claude query failed: Claude Code returned an error result: No conversation found with session ID: <uuid>
```

セッションが存在しない場合は新規セッションとして始めるよう修正した。

## 変更内容

- `claude/mod.ts`
  - `isSessionNotFoundError()` を追加。SDK の `No conversation found with session ID:` メッセージを判定する。
  - `askClaude()` を while ループに変更。`resume` 先のセッションが見つからず起動時に throw した場合、`resume` を外して新規セッションで **1 回だけ** やり直す。
  - 新しい `session_id` は従来どおり `result` イベント経由で各呼び出し元（chat / voice / cron）が `setSession` で保存し直すため、stale な ID は自動で上書きされる。
  - 再試行は **未 yield 時（`eventTypes.length === 0`）のみ** に限定。万一ストリーム途中で同種エラーが出ても下流が二重出力しないようにガードした。
  - session-not-found 以外のエラー、および再試行後の再失敗は従来どおり診断情報付きで再 throw する。

## テスト

`claude/mod.test.ts` に以下を追加。

- resume 先セッションが存在しない場合に resume を外して新規セッションで再試行すること
- 再試行は 1 回限りで、再び失敗すれば throw すること
- session-not-found 以外のエラーでは再試行しないこと
- 既に yield 済みなら session-not-found でも再試行しないこと
- `isSessionNotFoundError` の単体テスト

`deno task check` / `deno task test`（42 passed / 0 failed）/ `deno task lint` いずれも通過。

## 影響範囲

chat / voice / cron の 3 経路はすべて `askClaude()` を通るため、呼び出し元は無変更で恩恵を受ける。

🤖 Generated with [Claude Code](https://claude.com/claude-code)