### PR TITLE
feat: Claude の応答を assistant メッセージ境界ごとに分割投稿する

### DIFF
--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -515,6 +515,12 @@ export class DiscordBot {
           if (textBuffer.length >= FLUSH_THRESHOLD) {
             await flushBuffer(false);
           }
+        } else if (event.type === "assistant" && !event.parent_tool_use_id) {
+          // トップレベルの assistant メッセージ 1 件が完成した時点で強制フラッシュ。
+          // Claude が「テキスト → ツール実行 → テキスト」と複数の応答に分かれて
+          // 喋る場合、各応答を別々の Discord 投稿として区切るため。閾値による
+          // 途中フラッシュ (上の delta 分岐) は応答内のストリーミング体感のために残す。
+          await flushBuffer(true);
         } else if (event.type === "result") {
           resultEvent = event;
           // 非 success の subtype (error_max_turns 等) は Docker logs から原因を追えるよう詳細を残す。


### PR DESCRIPTION
## 概要

bot の応答を、Claude の応答 (assistant メッセージ) 1 件ごとに別々の Discord 投稿へ分割する。

これまでは複数の応答 (テキスト → ツール実行 → テキスト) が 1 つの `textBuffer` に連結され、最後にまとめて投稿されていた。閾値 (800 文字) に届かない限り、複数応答が 1 通にまとまる挙動だった。

## 変更内容

`bot/mod.ts` のストリーミング処理に、トップレベルの `assistant` メッセージ完成を検出する分岐を追加し、その時点で `flushBuffer(true)` する。

- `event.type === "assistant" && !event.parent_tool_use_id` を境界シグナルに使用 (サブエージェント由来は除外)
- 閾値による途中フラッシュ (delta 分岐) は応答内のストリーミング体感のため維持
- テキストを伴わない応答 (ツール実行のみ) では buffer が空なので no-op

## 挙動

- 複数応答 (テキスト → ツール → テキスト): 応答ごとに別投稿
- 長い単一応答: 従来どおり 800 文字閾値で途中投稿、2000 文字超は `splitMessage` で分割

## 検証

- `deno task check` 型チェック通過
- `deno task lint` (lint + fmt) クリーン
- `deno task test` 42 passed / 0 failed

`bot/mod.ts` は discord.js 統合コードのためユニットテスト対象外 (CLAUDE.md テスト方針)。実挙動確認はインテグレーション領域。

🤖 Generated with [Claude Code](https://claude.com/claude-code)