### PR TITLE
feat: 分割投稿の全メッセージに発言者メンションを付与する

### DIFF
--- a/bot/message.ts
+++ b/bot/message.ts
@@ -230,7 +230,7 @@ export function appendImageReferences(
 /**
  * Discord のメッセージ文字数上限。
  */
-const DISCORD_MESSAGE_LIMIT = 2000;
+export const DISCORD_MESSAGE_LIMIT = 2000;
 
 /**
  * テキストを Discord の文字数制限に収まるように分割する。

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -32,6 +32,7 @@ import {
   appendImageReferences,
   cleanupImageFiles,
   createProgressReporter,
+  DISCORD_MESSAGE_LIMIT,
   type DownloadedImage,
   downloadImageAttachments,
   keepTyping,
@@ -400,17 +401,14 @@ export class DiscordBot {
     const progress = createProgressReporter(channel);
     let downloadedImages: DownloadedImage[] = [];
 
-    // 応答は発言者宛にする: 最初の 1 通だけ先頭にメンションを付け、以降の
-    // チャンクは通常送信する（毎チャンクで発言者に通知が飛ぶのを防ぐ）。
-    // メンションは分割前のテキスト先頭に付けてから splitMessage に渡す。
-    // 先頭チャンクが上限ぎりぎりでもメンション分が溢れないようにするため。
+    // 応答は発言者宛にする: 分割後のすべての投稿の先頭にメンションを付ける。
+    // メンション分を引いた上限で分割してから各チャンク先頭に付与することで、
+    // どのチャンクでも上限ぎりぎりでメンション分が溢れない（2000 字超過しない）。
     const mention = `<@${message.author.id}> `;
-    let mentioned = false;
     const sendChunks = async (text: string): Promise<void> => {
-      const body = mentioned ? text : mention + text;
-      mentioned = true;
-      for (const chunk of splitMessage(body)) {
-        await channel.send(chunk);
+      const chunks = splitMessage(text, DISCORD_MESSAGE_LIMIT - mention.length);
+      for (const chunk of chunks) {
+        await channel.send(mention + chunk);
       }
     };
 


### PR DESCRIPTION
## 概要

assistant メッセージ境界ごとの分割投稿（#73）で、従来は最初の 1 通だけに発言者メンションを付けていた。分割後のどの投稿が通知されても発言者がたどれるよう、全投稿の先頭にメンションを付ける。

## 変更点

- `bot/mod.ts`: `sendChunks` の `mentioned` フラグを廃止。メンション分を引いた上限（`DISCORD_MESSAGE_LIMIT - mention.length`）で `splitMessage` してから各チャンク先頭にメンションを付与する。これで全投稿がメンション付きになり、かつメンション分を考慮した分割なので 2000 字上限の超過も起きない。
- `bot/message.ts`: `DISCORD_MESSAGE_LIMIT` を export し、mod.ts と上限値を共有する。

## トレードオフ

旧実装は通知スパム抑制のため「最初の 1 通だけメンション」という意図的設計だった。本変更で分割投稿のたびに発言者へ通知が飛ぶようになる（要望どおり）。

## 確認

- `deno task check` pass
- `deno task lint` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)