### PR TITLE
feat: thinking のヘッダ廃止と showThinking の per-scope 化 (#79 follow-up)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,14 +126,14 @@ config.schema.ts       config.schema.json を @cfworker/json-schema の Validato
 logger.ts              名前空間付き軽量ロガー。`initLogger({ level, bufferSize })` で設定。リングバッファで直近ログをメモリ保持。
 errors.ts              getErrorMessage(): unknown なエラー値からメッセージを取り出す共通ユーティリティ。
 bot/mod.ts             DiscordBot クラス。messageCreate ハンドラ、start/shutdown。
-bot/commands.ts        スラッシュコマンド定義とハンドラ（/claw status show|set|unset, /claw vc join|leave）。
+bot/commands.ts        スラッシュコマンド定義とハンドラ（/claw status show|set|unset で model/effort/show_thinking/session を操作, /claw vc join|leave）。
 bot/guard.ts           isAuthorized(): ギルド ID + ユーザー ID + bot 除外の認可チェック。shouldRespond(): active channel / mention / スレッドによる反応判定。
 bot/queue.ts           ScopeQueue: scope (localId) 単位でメッセージ処理を直列化するキュー。応答中の scope に届いた次のメッセージを現在のターン終了後に処理する (並行 query と session 競合の防止)。
 bot/message.ts         splitMessage(): 2000 文字分割。keepTyping(): typing インジケーター維持。ProgressReporter: ツール進捗表示。
 claude/mod.ts          askClaude(): Agent SDK の query() を呼び出し SDKMessage ストリームを逐次 yield。buildQueryOptions() / normalizeEffort()。テストは queryFn DI でモック。
 claude/system-prompt.ts  SystemPromptStore: .claude/system-prompt/ 配下を起動時に読み込み、コンテキスト (chat/vc/cron) とスコープ (channelId/threadId) に応じて結合。
 claude/template.ts     replaceTemplateVariables(): システムプロンプトの {{key}} 置換。
-store/mod.ts           Store: Deno KV (SQLite backend) によるスコープ単位の session_id / model / effort 永続化。スコープは {channelId, threadId?} の組。model / effort は thread → channel → グローバルデフォルト (config.json `defaults`) の動的フォールバック。session は thread と channel で独立。
+store/mod.ts           Store: Deno KV (SQLite backend) によるスコープ単位の session_id / model / effort / showThinking 永続化。スコープは {channelId, threadId?} の組。model / effort / showThinking は thread → channel → グローバルデフォルト (config.json `claude.defaults`) の動的フォールバック (showThinking は最終的に false)。session は thread と channel で独立。
 approval/manager.ts    ApprovalManager: Discord ボタンによるツール承認/拒否。createCanUseTool(): ApprovalResult を SDK の PermissionResult に変換する canUseTool コールバックを生成。
 approval/settings.ts   isInAllowList() / addToSettingsAllowList(): .claude/settings.json の permissions.allow 読み書き。
 api/server.ts              統合 HTTP サーバー。Hono アプリ作成、サブルート（cron / logs）マウント、共通エラーハンドラ。承認は in-process のため HTTP では扱わない。Discord 操作は Claude が公式 REST API を直接叩くため提供しない。
@@ -295,21 +295,21 @@ cron ジョブ用のシステムプロンプトは `.claude/system-prompt/CRON.m
 5. `message.cleanContent` からプロンプト抽出（bot mention を除去）
 6. `keepTyping()` で typing 開始
 7. `askClaude()` で Agent SDK の query() を実行し、`tool_progress` イベントで進捗表示
-8. `config.claude.showThinking` が `true` のとき、`thinking_delta`（推論）を `-# 思考` + `>` 引用形式で投稿（メンション無し）。thinking が流れるかは model / effort 依存
+8. Store から解決した `showThinking` が `true` のとき、`thinking_delta`（推論）を `>` 引用形式で投稿（メンション無し）。thinking が流れるかは model / effort 依存
 9. `Store` にスコープ単位で session ID を保存（次回 `query()` の `options.resume` で継続。thread と channel の session は独立）
 10. `splitMessage()` で応答を分割送信
 
 ### スコープと設定の解決
 
-各メッセージは `StoreScope` 単位で `session / model / effort` を持つ。
+各メッセージは `StoreScope` 単位で `session / model / effort / showThinking` を持つ。
 
 - **スレッド外** のメッセージ: `{ channelId }` スコープ
 - **スレッド内** のメッセージ: `{ channelId: parentId, threadId }` スコープ
 - **cron ジョブ**: `{ channelId: "cron:{name}" }` スコープ（thread 無し）
 - **ボイスチャンネル**: `{ channelId }` スコープ（VC はスレッドを持たない）
 
-`model / effort` の解決順は **thread → channel → グローバルデフォルト** の動的フォールバック。
-スレッドで `/claw status set model=...` を叩くと thread のみに保存され、親チャンネルの設定には影響しない。
+`model / effort / showThinking` の解決順は **thread → channel → グローバルデフォルト** の動的フォールバック。グローバルデフォルトは `config.json` の `claude.defaults`（`showThinking` は未設定時 false）。
+スレッドで `/claw status set model=...` を叩くと thread のみに保存され、親チャンネルの設定には影響しない。`showThinking` も同様に `/claw status set show_thinking=...` で per-scope に上書きでき、`/claw status unset show_thinking` でフォールバックへ戻せる。
 逆にスレッドで未設定なら親チャンネルの設定が即時に反映される。
 
 `session` は thread と channel で完全に独立する。スレッドを切ると新規セッションとして始まり、親チャンネル側のセッションは触らない。`/claw status unset session` をスレッド内で実行するとスレッドのセッションのみ削除する。

--- a/bot/commands.test.ts
+++ b/bot/commands.test.ts
@@ -34,7 +34,7 @@ const th = (channelId: string, threadId: string): StoreScope => ({
  */
 function mockInteraction(
   channelId: string,
-  options: Record<string, string>,
+  options: Record<string, string | boolean>,
   threadParentId?: string | null,
 ) {
   let replied = false;
@@ -56,7 +56,12 @@ function mockInteraction(
     channel,
     options: {
       getString(name: string, _required?: boolean) {
-        return options[name] ?? null;
+        const v = options[name];
+        return typeof v === "string" ? v : null;
+      },
+      getBoolean(name: string, _required?: boolean) {
+        const v = options[name];
+        return typeof v === "boolean" ? v : null;
       },
     },
     get replied() {
@@ -124,8 +129,37 @@ Deno.test("handleStatusSet", async (t) => {
         assertEquals(await store.getEffort(ch("ch-1")), undefined);
         assertEquals(
           interaction.getReplyContent(),
-          "Specify at least one of `model` or `effort`.",
+          "Specify at least one of `model` / `effort` / `show_thinking`.",
         );
+      }),
+  );
+
+  await t.step(
+    "show_thinking のみ指定で設定されること",
+    () =>
+      withStore(async (store) => {
+        const interaction = mockInteraction("ch-1", {
+          show_thinking: true,
+          // deno-lint-ignore no-explicit-any
+        }) as any;
+        await handleStatusSet(interaction, store);
+        assertEquals(await store.getShowThinking(ch("ch-1")), true);
+        assertEquals(await store.getModel(ch("ch-1")), undefined);
+      }),
+  );
+
+  await t.step(
+    "show_thinking = false も明示指定として保存されること",
+    () =>
+      withStore(async (store) => {
+        // defaults true でも channel に false を明示できる
+        await store.setShowThinking(ch("ch-1"), true);
+        const interaction = mockInteraction("ch-1", {
+          show_thinking: false,
+          // deno-lint-ignore no-explicit-any
+        }) as any;
+        await handleStatusSet(interaction, store);
+        assertEquals(await store.getShowThinking(ch("ch-1")), false);
       }),
   );
 
@@ -208,6 +242,25 @@ Deno.test("handleStatusUnset", async (t) => {
         await handleStatusUnset(interaction, store);
 
         assertEquals(await store.getEffort(ch("ch-1")), undefined);
+        assertEquals(await store.getModel(ch("ch-1")), "opus");
+      }),
+  );
+
+  await t.step(
+    "target=show_thinking でチャンネルの showThinking のみ削除されること",
+    () =>
+      withStore(async (store) => {
+        await store.setShowThinking(ch("ch-1"), true);
+        await store.setModel(ch("ch-1"), "opus");
+
+        const interaction = mockInteraction("ch-1", {
+          target: "show_thinking",
+          // deno-lint-ignore no-explicit-any
+        }) as any;
+        await handleStatusUnset(interaction, store);
+
+        // 削除後は defaults (= false) へフォールバック
+        assertEquals(await store.getShowThinking(ch("ch-1")), false);
         assertEquals(await store.getModel(ch("ch-1")), "opus");
       }),
   );

--- a/bot/commands.ts
+++ b/bot/commands.ts
@@ -39,6 +39,7 @@ const EFFORT_CHOICES = [
 const UNSET_TARGET_CHOICES = [
   { name: "model", value: "model" },
   { name: "effort", value: "effort" },
+  { name: "show_thinking", value: "show_thinking" },
   { name: "session", value: "session" },
 ] as const;
 
@@ -63,7 +64,7 @@ export const command = new SlashCommandBuilder()
         sub
           .setName("set")
           .setDescription(
-            "Set channel-level model / effort (specify at least one)",
+            "Set channel-level model / effort / show_thinking (specify at least one)",
           )
           .addStringOption((opt) =>
             opt
@@ -79,12 +80,18 @@ export const command = new SlashCommandBuilder()
               .setRequired(false)
               .addChoices(...EFFORT_CHOICES)
           )
+          .addBooleanOption((opt) =>
+            opt
+              .setName("show_thinking")
+              .setDescription("Show thinking (reasoning) in this channel")
+              .setRequired(false)
+          )
       )
       .addSubcommand((sub) =>
         sub
           .setName("unset")
           .setDescription(
-            "Clear channel-level setting (model / effort / session)",
+            "Clear channel-level setting (model / effort / show_thinking / session)",
           )
           .addStringOption((opt) =>
             opt
@@ -207,6 +214,9 @@ export async function handleStatusShow(
   );
   lines.push(`- model: ${formatSetting(settings.model)}`);
   lines.push(`- effort: ${formatSetting(settings.effort)}`);
+  lines.push(
+    `- show_thinking: \`${settings.showThinking.value}\` (${settings.showThinking.source})`,
+  );
 
   // グローバルデフォルト
   lines.push("");
@@ -221,6 +231,7 @@ export async function handleStatusShow(
       deps.defaults.effort ? `\`${deps.defaults.effort}\`` : "(unset)"
     }`,
   );
+  lines.push(`- show_thinking: \`${deps.defaults.showThinking ?? false}\``);
 
   // cron
   lines.push("");
@@ -267,10 +278,11 @@ export async function handleStatusSet(
 ): Promise<void> {
   const model = interaction.options.getString("model");
   const effort = interaction.options.getString("effort");
+  const showThinking = interaction.options.getBoolean("show_thinking");
 
-  if (!model && !effort) {
+  if (!model && !effort && showThinking === null) {
     await interaction.reply({
-      content: "Specify at least one of `model` or `effort`.",
+      content: "Specify at least one of `model` / `effort` / `show_thinking`.",
       flags: MessageFlags.Ephemeral,
     });
     return;
@@ -287,6 +299,10 @@ export async function handleStatusSet(
   if (effort) {
     await store.setEffort(scope, effort);
     updates.push(`effort = \`${effort}\``);
+  }
+  if (showThinking !== null) {
+    await store.setShowThinking(scope, showThinking);
+    updates.push(`show_thinking = \`${showThinking}\``);
   }
   await interaction.reply({
     content: `Updated for this ${scopeLabel}: ${updates.join(", ")}.`,
@@ -331,6 +347,14 @@ export async function handleStatusUnset(
       await store.deleteEffort(scope);
       await interaction.reply({
         content: `Effort unset for this ${scopeLabel} (fallback applies).`,
+        flags: MessageFlags.Ephemeral,
+      });
+      break;
+    case "show_thinking":
+      await store.deleteShowThinking(scope);
+      await interaction.reply({
+        content:
+          `Show_thinking unset for this ${scopeLabel} (fallback applies).`,
         flags: MessageFlags.Ephemeral,
       });
       break;

--- a/bot/guard.test.ts
+++ b/bot/guard.test.ts
@@ -16,7 +16,6 @@ const baseConfig: Config = {
     timeout: 300000,
     cwd: "/tmp",
     apiPort: 3000,
-    showThinking: false,
     defaults: {},
   },
   voice: {

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -444,11 +444,10 @@ export class DiscordBot {
       };
 
       // thinking (推論) を引用形式で投稿する。回答ではないのでメンションは付けず、
-      // Discord の `-# ` 小文字 + `> ` 引用で回答と視覚的に分離する。
-      const showThinking = this.config.claude.showThinking;
+      // Discord の `> ` 引用で回答と視覚的に分離する。
       const sendThinking = async (text: string): Promise<void> => {
         const quoted = text.split("\n").map((line) => `> ${line}`).join("\n");
-        for (const chunk of splitMessage(`-# 思考\n${quoted}`)) {
+        for (const chunk of splitMessage(quoted)) {
           await channel.send(chunk);
         }
       };
@@ -472,10 +471,11 @@ export class DiscordBot {
           return;
         }
 
-        const [sessionId, model, effort] = await Promise.all([
+        const [sessionId, model, effort, showThinking] = await Promise.all([
           this.store.getSession(scope),
           this.store.getModel(scope),
           this.store.getEffort(scope),
+          this.store.getShowThinking(scope),
         ]);
 
         // 承認ボタンの送信先は発話があった場所 (スレッド優先)

--- a/claude/mod.test.ts
+++ b/claude/mod.test.ts
@@ -20,7 +20,6 @@ const baseConfig: ClaudeConfig = {
   timeout: 300000,
   cwd: "/workspace",
   apiPort: 3000,
-  showThinking: false,
   defaults: {},
 };
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -49,24 +49,12 @@
       "description": "Claude 呼び出し (Agent SDK query()) の挙動とグローバルデフォルト。",
       "default": {},
       "additionalProperties": false,
-      "required": [
-        "maxTurns",
-        "verbose",
-        "timeout",
-        "apiPort",
-        "showThinking",
-        "defaults"
-      ],
+      "required": ["maxTurns", "verbose", "timeout", "apiPort", "defaults"],
       "properties": {
         "maxTurns": {
           "type": "number",
           "default": 10,
           "description": "エージェントの最大ターン数（query() の maxTurns に渡される）。"
-        },
-        "showThinking": {
-          "type": "boolean",
-          "default": false,
-          "description": "thinking（推論）を Discord に表示するか。true のとき、ストリームに流れてきた thinking ブロックを引用形式で投稿する。thinking が流れるかは model / effort 依存（effort: low 等では出ないことがある）。"
         },
         "verbose": {
           "type": "boolean",
@@ -97,6 +85,11 @@
               "type": "string",
               "enum": ["low", "medium", "high", "xhigh", "max"],
               "description": "デフォルト effort level。省略可。"
+            },
+            "showThinking": {
+              "type": "boolean",
+              "default": false,
+              "description": "thinking（推論）を Discord に表示するか。チャンネル / スレッド単位の上書きが無いときに使われるグローバルデフォルト。/claw status set show_thinking で per-scope に上書きできる。true のとき、ストリームに流れてきた thinking ブロックを引用形式で投稿する。thinking が流れるかは model / effort 依存（effort: low 等では出ないことがある）。"
             }
           }
         }

--- a/config.test.ts
+++ b/config.test.ts
@@ -52,7 +52,7 @@ Deno.test("loadConfig", async (t) => {
       assertEquals(config.claude.verbose, true);
       assertEquals(config.claude.timeout, 300000);
       assertEquals(config.claude.apiPort, 3000);
-      assertEquals(config.claude.showThinking, false);
+      assertEquals(config.claude.defaults.showThinking, false);
       assertEquals(config.voice.enabled, false);
       assertEquals(config.voice.whisper.url, "http://localhost:8178");
       assertEquals(config.voice.whisper.noSpeechProbThreshold, 0.6);

--- a/config.ts
+++ b/config.ts
@@ -23,6 +23,8 @@ export interface ClaudeDefaults {
   model?: string;
   /** デフォルトの effort level (low / medium / high / xhigh / max)。 */
   effort?: string;
+  /** thinking（推論）を Discord に表示するか。省略時は false 扱い。 */
+  showThinking?: boolean;
 }
 
 /**
@@ -37,8 +39,6 @@ export interface ClaudeConfig {
   timeout: number;
   /** 内部 API サーバーのポート（cron + ログ）。 */
   apiPort: number;
-  /** thinking（推論）を Discord に表示するか。 */
-  showThinking: boolean;
   /** `query()` の作業ディレクトリ。実行時に `Deno.cwd()` が注入される。 */
   cwd: string;
   /** Claude のグローバルデフォルト (model / effort)。 */

--- a/cron/executor.test.ts
+++ b/cron/executor.test.ts
@@ -113,7 +113,6 @@ const TEST_CONFIG = {
   timeout: 30000,
   cwd: "/tmp",
   apiPort: 3000,
-  showThinking: false,
   defaults: {},
 };
 

--- a/data/config.json.example
+++ b/data/config.json.example
@@ -12,10 +12,10 @@
     "verbose": true,
     "timeout": 300000,
     "apiPort": 3000,
-    "showThinking": false,
     "defaults": {
       "model": "sonnet",
-      "effort": "medium"
+      "effort": "medium",
+      "showThinking": false
     }
   },
   "voice": {

--- a/store/mod.test.ts
+++ b/store/mod.test.ts
@@ -246,6 +246,74 @@ Deno.test("Store - effort", async (t) => {
   );
 });
 
+Deno.test("Store - showThinking", async (t) => {
+  await t.step(
+    "未登録 + defaults 無しで false を返すこと",
+    async () => {
+      await withStore({}, async (store) => {
+        assertEquals(await store.getShowThinking(ch("ch-1")), false);
+      });
+    },
+  );
+
+  await t.step(
+    "defaults が true なら true を返すこと",
+    async () => {
+      await withStore({ showThinking: true }, async (store) => {
+        assertEquals(await store.getShowThinking(ch("ch-1")), true);
+      });
+    },
+  );
+
+  await t.step(
+    "channel 上書きが defaults より優先されること",
+    async () => {
+      await withStore({ showThinking: true }, async (store) => {
+        await store.setShowThinking(ch("ch-1"), false);
+        assertEquals(await store.getShowThinking(ch("ch-1")), false);
+      });
+    },
+  );
+
+  await t.step("delete 後は defaults に戻ること", async () => {
+    await withStore({ showThinking: true }, async (store) => {
+      await store.setShowThinking(ch("ch-1"), false);
+      await store.deleteShowThinking(ch("ch-1"));
+      assertEquals(await store.getShowThinking(ch("ch-1")), true);
+    });
+  });
+
+  await t.step(
+    "thread 値が channel / defaults より優先されること",
+    async () => {
+      await withStore({ showThinking: false }, async (store) => {
+        await store.setShowThinking(ch("ch-1"), false);
+        await store.setShowThinking(th("ch-1", "th-1"), true);
+        assertEquals(await store.getShowThinking(th("ch-1", "th-1")), true);
+      });
+    },
+  );
+
+  await t.step(
+    "thread 未設定なら channel 値にフォールバックすること",
+    async () => {
+      await withStore({ showThinking: false }, async (store) => {
+        await store.setShowThinking(ch("ch-1"), true);
+        assertEquals(await store.getShowThinking(th("ch-1", "th-1")), true);
+      });
+    },
+  );
+
+  await t.step(
+    "thread / channel 共に未設定なら defaults に戻ること",
+    async () => {
+      await withStore({ showThinking: true }, async (store) => {
+        assertEquals(await store.getShowThinking(th("ch-1", "th-1")), true);
+      });
+    },
+  );
+});
+
 Deno.test("Store - clearScope", async (t) => {
   await t.step(
     "channel スコープで session / model / effort が同時に削除され、defaults は残ること",
@@ -391,6 +459,27 @@ Deno.test("Store - getScopeSettings", async (t) => {
         await store.setSession(ch("ch-1"), "session-channel");
         const s = await store.getScopeSettings(th("ch-1", "th-1"));
         assertEquals(s.session, undefined);
+      });
+    },
+  );
+
+  await t.step(
+    "showThinking は未設定でも false (source: default) で返ること",
+    async () => {
+      await withStore({}, async (store) => {
+        const s = await store.getScopeSettings(ch("ch-1"));
+        assertEquals(s.showThinking, { value: false, source: "default" });
+      });
+    },
+  );
+
+  await t.step(
+    "showThinking の channel 上書きが source 'channel' で返ること",
+    async () => {
+      await withStore({ showThinking: false }, async (store) => {
+        await store.setShowThinking(ch("ch-1"), true);
+        const s = await store.getScopeSettings(ch("ch-1"));
+        assertEquals(s.showThinking, { value: true, source: "channel" });
       });
     },
   );

--- a/store/mod.ts
+++ b/store/mod.ts
@@ -1,18 +1,18 @@
 /**
  * チャンネル / スレッド単位の永続化ストア。
  *
- * Deno KV (SQLite backend) に session_id / model / effort を保存する。
+ * Deno KV (SQLite backend) に session_id / model / effort / showThinking を保存する。
  *
  * スコープは {channelId, threadId?} の組で表す。
  *   - threadId 無し: 通常チャンネル (= スレッドではないテキストチャンネル) または
  *     cron の擬似 channelId (`cron:{name}`) など。
  *   - threadId あり: スレッド。フォールバック先として親チャンネルを参照する。
  *
- * model / effort は thread → channel → defaults の順に解決する。
+ * model / effort / showThinking は thread → channel → defaults の順に解決する。
  * session は thread と channel で完全に独立し、互いにフォールバックしない。
  *
  * KV キー設計:
- *   ["channel", id, "session" | "model" | "effort"] -> string
+ *   ["channel", id, "session" | "model" | "effort" | "showThinking"] -> string
  *   id は Discord Snowflake (channel / thread どちらも) または `cron:{name}`。
  *   thread と channel は同一 Snowflake 名前空間で衝突しないため、id をそのまま
  *   キーに使い分ける。
@@ -24,6 +24,7 @@ const NS = "channel";
 const SESSION = "session";
 const MODEL = "model";
 const EFFORT = "effort";
+const SHOW_THINKING = "showThinking";
 
 /**
  * グローバルデフォルト値。チャンネル / スレッド単位の上書きが無いときに使われる。
@@ -31,6 +32,7 @@ const EFFORT = "effort";
 export interface StoreDefaults {
   model?: string;
   effort?: string;
+  showThinking?: boolean;
 }
 
 /**
@@ -58,12 +60,22 @@ export interface ScopeSettingEntry {
 }
 
 /**
+ * boolean 設定値とその出所を表すエントリ。
+ */
+export interface BoolScopeSettingEntry {
+  value: boolean;
+  source: SettingSource;
+}
+
+/**
  * スコープ単位の設定スナップショット。
  */
 export interface ScopeSettings {
   session?: string;
   model?: ScopeSettingEntry;
   effort?: ScopeSettingEntry;
+  /** showThinking は未設定でも false (source: default) として常に解決する。 */
+  showThinking: BoolScopeSettingEntry;
 }
 
 /**
@@ -157,6 +169,42 @@ export class Store {
     await this.kv.delete([NS, id, EFFORT]);
   }
 
+  // ── showThinking ────────────────────────────────────────
+  // thread → channel → defaults の順で解決。boolean は KV に "true" / "false"
+  // の文字列で格納する (KV 値を文字列で統一するため)。未設定なら false。
+
+  async getShowThinking(scope: StoreScope): Promise<boolean> {
+    if (scope.threadId !== undefined) {
+      const threadEntry = await this.kv.get<string>([
+        NS,
+        scope.threadId,
+        SHOW_THINKING,
+      ]);
+      if (threadEntry.value !== null) {
+        return threadEntry.value === "true";
+      }
+    }
+    const channelEntry = await this.kv.get<string>([
+      NS,
+      scope.channelId,
+      SHOW_THINKING,
+    ]);
+    if (channelEntry.value !== null) {
+      return channelEntry.value === "true";
+    }
+    return this.defaults.showThinking ?? false;
+  }
+
+  async setShowThinking(scope: StoreScope, value: boolean): Promise<void> {
+    const id = scope.threadId ?? scope.channelId;
+    await this.kv.set([NS, id, SHOW_THINKING], String(value));
+  }
+
+  async deleteShowThinking(scope: StoreScope): Promise<void> {
+    const id = scope.threadId ?? scope.channelId;
+    await this.kv.delete([NS, id, SHOW_THINKING]);
+  }
+
   // ── まとめ操作 ─────────────────────────────────────────
 
   /**
@@ -194,12 +242,14 @@ export class Store {
       [NS, scope.channelId, SESSION],
       [NS, scope.channelId, MODEL],
       [NS, scope.channelId, EFFORT],
+      [NS, scope.channelId, SHOW_THINKING],
     ] as const;
 
     if (scope.threadId === undefined) {
-      const [sessionEntry, modelEntry, effortEntry] = await this.kv.getMany<
-        [string, string, string]
-      >([...channelKeys]);
+      const [sessionEntry, modelEntry, effortEntry, showThinkingEntry] =
+        await this.kv.getMany<
+          [string, string, string, string]
+        >([...channelKeys]);
       return {
         session: sessionEntry.value ?? undefined,
         model: resolveSetting(
@@ -212,6 +262,11 @@ export class Store {
           effortEntry.value,
           this.defaults.effort,
         ),
+        showThinking: resolveBoolSetting(
+          null,
+          showThinkingEntry.value,
+          this.defaults.showThinking,
+        ),
       };
     }
 
@@ -219,16 +274,19 @@ export class Store {
       [NS, scope.threadId, SESSION],
       [NS, scope.threadId, MODEL],
       [NS, scope.threadId, EFFORT],
+      [NS, scope.threadId, SHOW_THINKING],
     ] as const;
     const [
       threadSession,
       threadModel,
       threadEffort,
+      threadShowThinking,
       _channelSession,
       channelModel,
       channelEffort,
+      channelShowThinking,
     ] = await this.kv.getMany<
-      [string, string, string, string, string, string]
+      [string, string, string, string, string, string, string, string]
     >([...threadKeys, ...channelKeys]);
 
     return {
@@ -243,6 +301,11 @@ export class Store {
         threadEffort.value,
         channelEffort.value,
         this.defaults.effort,
+      ),
+      showThinking: resolveBoolSetting(
+        threadShowThinking.value,
+        channelShowThinking.value,
+        this.defaults.showThinking,
       ),
     };
   }
@@ -270,4 +333,25 @@ function resolveSetting(
     return { value: defaultValue, source: "default" };
   }
   return undefined;
+}
+
+/**
+ * boolean 設定値を thread → channel → default の順で解決する。
+ *
+ * KV には "true" / "false" の文字列で格納されている。model / effort と違い、
+ * boolean は「未設定 = false」という確定した既定値があるため、どこにも値が
+ * 無いときも `{ value: false, source: "default" }` を返す (undefined にしない)。
+ */
+function resolveBoolSetting(
+  threadValue: string | null,
+  channelValue: string | null,
+  defaultValue: boolean | undefined,
+): BoolScopeSettingEntry {
+  if (threadValue !== null) {
+    return { value: threadValue === "true", source: "thread" };
+  }
+  if (channelValue !== null) {
+    return { value: channelValue === "true", source: "channel" };
+  }
+  return { value: defaultValue ?? false, source: "default" };
 }

--- a/voice/adapter.test.ts
+++ b/voice/adapter.test.ts
@@ -10,7 +10,6 @@ const baseConfig: ClaudeConfig = {
   timeout: 300000,
   cwd: "/workspace",
   apiPort: 3000,
-  showThinking: false,
   defaults: {},
 };
 


### PR DESCRIPTION
#79 のレビュー指摘の反映。#79 は squash merge 済みのため新規 PR として出す。

## 変更点

### 1. thinking の「思考」ヘッダ廃止

thinking 投稿から `-# 思考` ヘッダを除去し、`>` 引用のみにする。

### 2. showThinking を `claude.defaults` へ移して per-scope 化

`#79` では `config.claude.showThinking` をグローバル設定として読んでいたが、`model` / `effort` と同じく **thread → channel → グローバルデフォルト** のフォールバックで per-scope 解決するようにした (最終 false)。`claude.defaults` は Store のフォールバック元という役割を持つため、そこに置く以上は解決機構も揃える。

- `store/mod.ts`: `getShowThinking` / `setShowThinking` / `deleteShowThinking` と `StoreDefaults.showThinking` を追加。`getScopeSettings` に showThinking を含める (未設定でも `{ value: false, source: "default" }` を返す)。KV には `"true"` / `"false"` の文字列で格納。
- `bot/mod.ts`: showThinking を Store から解決する (`Promise.all` に追加)。thinking 投稿時の参照もこの解決値に変更。
- `bot/commands.ts`: `/claw status set show_thinking:<bool>`、`/claw status unset show_thinking`、`/claw status show` の表示に対応。
- config: `config.schema.json` / `config.ts` / `data/config.json.example` で `claude.showThinking` → `claude.defaults.showThinking` (boolean, default `false`) へ移動。

## テスト

- `store/mod.test.ts`: showThinking の per-scope 解決 (thread/channel/default フォールバック、delete 後の復帰、getScopeSettings) を追加。
- `bot/commands.test.ts`: `handleStatusSet` / `handleStatusUnset` の show_thinking ケースを追加。
- `deno task check` / `deno task lint` / `deno task test` (44 passed, 0 failed) いずれも通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)