### PR TITLE
test: SDK 0.3.199 の CanUseTool 型変更に追従

### DIFF
--- a/approval/manager.test.ts
+++ b/approval/manager.test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import {
   type ApprovalManager,
   type ApprovalResult,
@@ -22,6 +22,7 @@ function mockManager(result: ApprovalResult): ApprovalManager {
 const toolOptions = {
   signal: new AbortController().signal,
   toolUseID: "tu-1",
+  requestId: "req-1",
 };
 
 Deno.test("createCanUseTool", async (t) => {
@@ -35,6 +36,7 @@ Deno.test("createCanUseTool", async (t) => {
       const input = { command: "ls" };
       const result = await canUseTool("Bash", input, toolOptions);
 
+      assertExists(result);
       assertEquals(result.behavior, "allow");
       if (result.behavior === "allow") {
         assertEquals(result.updatedInput, input);
@@ -51,6 +53,7 @@ Deno.test("createCanUseTool", async (t) => {
       );
       const result = await canUseTool("Bash", { command: "rm" }, toolOptions);
 
+      assertExists(result);
       assertEquals(result.behavior, "deny");
       if (result.behavior === "deny") {
         assertEquals(result.message, "Denied by user");
@@ -67,6 +70,7 @@ Deno.test("createCanUseTool", async (t) => {
       );
       const result = await canUseTool("Bash", {}, toolOptions);
 
+      assertExists(result);
       assertEquals(result.behavior, "deny");
       if (result.behavior === "deny") {
         assertEquals(result.message, "Denied");


### PR DESCRIPTION
## 概要

`build: upgrade` で Claude Agent SDK が `0.3.199` に上がり、`canUseTool` コールバックの型が変わったことで `approval/manager.test.ts` の型チェックが失敗していた。テスト側の型前提を新 API に追従させる。

## 変更点

- SDK 0.3.199 の `CanUseTool` は `options` 引数に `requestId: string` が必須追加され、戻り値が `Promise<PermissionResult | null>` になった。
  - モックの `toolOptions` に `requestId` を追加。
  - 各 `result` を `assertExists` で非 null に絞り、`behavior` / `message` アクセスの型エラー (TS18047 / TS2339) を解消。
- 実装 `approval/manager.ts` は無変更。null を足しただけの後方互換な型変更のため、`PermissionResult` を返す実装側はそのまま有効。

## 確認

- `deno task test`: 44 passed (298 steps) / 0 failed
- `deno task check`: エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)