### PR TITLE
feat: AskUserQuestion を Discord の select menu で回答できるように対応

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,8 @@ claude/mod.ts          askClaude(): Agent SDK の query() を呼び出し SDKMes
 claude/system-prompt.ts  SystemPromptStore: .claude/system-prompt/ 配下を起動時に読み込み、コンテキスト (chat/vc/cron) とスコープ (channelId/threadId) に応じて結合。
 claude/template.ts     replaceTemplateVariables(): システムプロンプトの {{key}} 置換。
 store/mod.ts           Store: Deno KV (SQLite backend) によるスコープ単位の session_id / model / effort / showThinking 永続化。スコープは {channelId, threadId?} の組。model / effort / showThinking は thread → channel → グローバルデフォルト (config.json `claude.defaults`) の動的フォールバック (showThinking は最終的に false)。session は thread と channel で独立。
-approval/manager.ts    ApprovalManager: Discord ボタンによるツール承認/拒否。createCanUseTool(): ApprovalResult を SDK の PermissionResult に変換する canUseTool コールバックを生成。
+approval/manager.ts    ApprovalManager: Discord ボタンによるツール承認/拒否。createCanUseTool(): ApprovalResult を SDK の PermissionResult に変換する canUseTool コールバックを生成。AskUserQuestion は承認フローを通さず QuestionManager へ委譲する。
+approval/question.ts   QuestionManager: AskUserQuestion の質問を Discord の select menu で提示し回答を収集。「Other (自由入力)」は Modal で受け付け、回答を updatedInput.answers として返す。
 approval/settings.ts   isInAllowList() / addToSettingsAllowList(): .claude/settings.json の permissions.allow 読み書き。
 api/server.ts              統合 HTTP サーバー。Hono アプリ作成、サブルート（cron / logs）マウント、共通エラーハンドラ。承認は in-process のため HTTP では扱わない。Discord 操作は Claude が公式 REST API を直接叩くため提供しない。
 api/routes/cron.ts         cron ルート（GET /cron, POST /cron/run, POST /cron/reload）。
@@ -359,6 +360,7 @@ Claude からは Bash + curl で呼び出す（ツール承認は in-process の
 - in-process `canUseTool` コールバック: ツール使用前に Discord にボタンを送信してユーザーが承認/拒否（デフォルト動作）。`createCanUseTool()` が `ApprovalManager.requestApproval()` を呼び、結果を SDK の `PermissionResult` に変換する。
 - `.claude/settings.json` の `permissions.allow`: 事前に許可するツール（ボタン確認をスキップ）。`settingSources: ["user", "project"]` で読み込まれる。
 - bypass モード: `permissionMode: "bypassPermissions"`（+ `allowDangerouslySkipPermissions`）で全ツール無条件許可（必要時のみ）。
+- `AskUserQuestion`: Claude からの質問（選択式）。承認ではなく回答収集のツールで、`createCanUseTool()` が `QuestionManager` に委譲して select menu（+ Other 自由入力の Modal）で回答を集め、`updatedInput.answers` に載せて allow で返す。キャンセル・タイムアウト（5 分）は deny となり、モデルは回答なしで続行する。**`permissions.allow` に `AskUserQuestion` を入れないこと**（SDK が `canUseTool` を呼ばず素通しし、回答が空のまま解決されるため）。
 
 ## 設定ファイル
 

--- a/approval/manager.test.ts
+++ b/approval/manager.test.ts
@@ -4,18 +4,45 @@ import {
   type ApprovalResult,
   createCanUseTool,
 } from "./manager.ts";
+import type { QuestionResult } from "./question.ts";
 
 /**
- * requestApproval が固定の ApprovalResult を返すモック ApprovalManager。
+ * requestApproval / requestAnswers が固定の結果を返すモック ApprovalManager。
  */
-function mockManager(result: ApprovalResult): ApprovalManager {
+function mockManager(
+  result: ApprovalResult,
+  answersResult?: QuestionResult,
+): ApprovalManager {
   return {
     requestApproval: (
       _toolName: string,
       _toolInput: Record<string, unknown>,
       _channelId?: string,
     ) => Promise.resolve(result),
+    requestAnswers: () =>
+      Promise.resolve(
+        answersResult ?? { kind: "denied", reason: "unexpected" },
+      ),
   } as unknown as ApprovalManager;
+}
+
+/**
+ * AskUserQuestion の正しい入力を生成する。
+ */
+function askUserQuestionInput(): Record<string, unknown> {
+  return {
+    questions: [
+      {
+        question: "Which one?",
+        header: "Choice",
+        options: [
+          { label: "A", description: "a" },
+          { label: "B", description: "b" },
+        ],
+        multiSelect: false,
+      },
+    ],
+  };
 }
 
 /** canUseTool の第 3 引数 (options) の最小モック。 */
@@ -74,6 +101,71 @@ Deno.test("createCanUseTool", async (t) => {
       assertEquals(result.behavior, "deny");
       if (result.behavior === "deny") {
         assertEquals(result.message, "Denied");
+      }
+    },
+  );
+
+  await t.step(
+    "AskUserQuestion の回答を updatedInput.answers に載せて allow すること",
+    async () => {
+      const canUseTool = createCanUseTool(
+        mockManager({ decision: "deny" }, {
+          kind: "answered",
+          answers: { "Which one?": "A" },
+        }),
+        "ch-1",
+      );
+      const input = askUserQuestionInput();
+      const result = await canUseTool("AskUserQuestion", input, toolOptions);
+
+      assertExists(result);
+      assertEquals(result.behavior, "allow");
+      if (result.behavior === "allow") {
+        assertEquals(result.updatedInput, {
+          ...input,
+          answers: { "Which one?": "A" },
+        });
+      }
+    },
+  );
+
+  await t.step(
+    "AskUserQuestion のキャンセル・タイムアウトは deny に変換すること",
+    async () => {
+      const canUseTool = createCanUseTool(
+        mockManager({ decision: "allow" }, {
+          kind: "denied",
+          reason: "Timed out",
+        }),
+        "ch-1",
+      );
+      const result = await canUseTool(
+        "AskUserQuestion",
+        askUserQuestionInput(),
+        toolOptions,
+      );
+
+      assertExists(result);
+      assertEquals(result.behavior, "deny");
+      if (result.behavior === "deny") {
+        assertEquals(result.message, "The user did not answer (Timed out)");
+      }
+    },
+  );
+
+  await t.step(
+    "AskUserQuestion の不正な入力は承認フローに回さず deny すること",
+    async () => {
+      const canUseTool = createCanUseTool(
+        mockManager({ decision: "allow" }),
+        "ch-1",
+      );
+      const result = await canUseTool("AskUserQuestion", {}, toolOptions);
+
+      assertExists(result);
+      assertEquals(result.behavior, "deny");
+      if (result.behavior === "deny") {
+        assertEquals(result.message, "Malformed AskUserQuestion input");
       }
     },
   );

--- a/approval/manager.ts
+++ b/approval/manager.ts
@@ -18,7 +18,17 @@ import type {
   CanUseTool,
   PermissionBehavior,
 } from "@anthropic-ai/claude-agent-sdk";
+import type {
+  ModalSubmitInteraction,
+  StringSelectMenuInteraction,
+} from "discord.js";
 import { addToSettingsAllowList, isInAllowList } from "./settings.ts";
+import {
+  parseQuestions,
+  type Question,
+  QuestionManager,
+  type QuestionResult,
+} from "./question.ts";
 import { createLogger } from "../logger.ts";
 import { getErrorMessage } from "../errors.ts";
 
@@ -49,8 +59,11 @@ export class ApprovalManager {
     }
   >();
   private channelId: string | null = null;
+  private questions: QuestionManager;
 
-  constructor(private client: Client, private settingsPath: string) {}
+  constructor(private client: Client, private settingsPath: string) {
+    this.questions = new QuestionManager(client);
+  }
 
   /**
    * 承認リクエストの送信先チャンネルを設定する。
@@ -137,9 +150,45 @@ export class ApprovalManager {
   }
 
   /**
+   * AskUserQuestion の質問への回答をリクエストする。
+   *
+   * チャンネル解決 (引数 → setChannel() の fallback) はここで行い、
+   * 質問メッセージの送信・回答収集は {@link QuestionManager} に委譲する。
+   */
+  requestAnswers(
+    questions: Question[],
+    channelId?: string,
+  ): Promise<QuestionResult> {
+    return this.questions.requestAnswers(
+      questions,
+      channelId ?? this.channelId ?? undefined,
+    );
+  }
+
+  /**
+   * 質問の select メニューのインタラクションを処理する。
+   */
+  handleSelect(interaction: StringSelectMenuInteraction): Promise<boolean> {
+    return this.questions.handleSelect(interaction);
+  }
+
+  /**
+   * 質問の Other (自由入力) Modal のインタラクションを処理する。
+   */
+  handleModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+    return this.questions.handleModal(interaction);
+  }
+
+  /**
    * ボタンインタラクションを処理する。
+   *
+   * 質問の Cancel ボタン → 承認ボタンの順に判定する。
    */
   async handleButton(interaction: ButtonInteraction): Promise<boolean> {
+    if (await this.questions.handleButton(interaction)) {
+      return true;
+    }
+
     const parts = interaction.customId.split(":");
     const action = parts[0];
     const requestId = parts[1];
@@ -202,12 +251,40 @@ export class ApprovalManager {
  *
  * `requestApproval` の結果 (`ApprovalResult`) を SDK の `PermissionResult` に
  * 変換する。allow 時は入力をそのまま echo back し、deny 時は理由を message に載せる。
+ *
+ * `AskUserQuestion` は承認ではなく回答収集のツールなので承認フローを通さず、
+ * `requestAnswers` で集めた回答を `updatedInput.answers` (質問文 → 選択ラベル)
+ * に載せて allow で返す。キャンセル・タイムアウト時は deny で返し、モデルは
+ * 回答なしで続行する。
+ *
+ * 注意: `.claude/settings.json` の `permissions.allow` に `AskUserQuestion` を
+ * 入れると SDK が canUseTool を呼ばずに素通しし、回答が空のまま解決される。
+ * このツールは allow list に入れないこと。
  */
 export function createCanUseTool(
   manager: ApprovalManager,
   channelId?: string,
 ): CanUseTool {
   return async (toolName, input) => {
+    if (toolName === "AskUserQuestion") {
+      const questions = parseQuestions(input);
+      if (!questions) {
+        log.warn("malformed AskUserQuestion input");
+        return { behavior: "deny", message: "Malformed AskUserQuestion input" };
+      }
+      const result = await manager.requestAnswers(questions, channelId);
+      if (result.kind === "answered") {
+        return {
+          behavior: "allow",
+          updatedInput: { ...input, answers: result.answers },
+        };
+      }
+      return {
+        behavior: "deny",
+        message: `The user did not answer (${result.reason})`,
+      };
+    }
+
     const result = await manager.requestApproval(toolName, input, channelId);
     if (result.decision === "allow") {
       return { behavior: "allow", updatedInput: input };

--- a/approval/question.test.ts
+++ b/approval/question.test.ts
@@ -1,0 +1,160 @@
+import { assertEquals } from "@std/assert";
+import {
+  formatAnswer,
+  OTHER_VALUE,
+  parseQuestions,
+  type Question,
+  resolveSelectedLabels,
+  truncate,
+} from "./question.ts";
+
+/**
+ * テスト用の質問入力を生成する。
+ */
+function validInput(): Record<string, unknown> {
+  return {
+    questions: [
+      {
+        question: "Which library should we use?",
+        header: "Library",
+        options: [
+          { label: "date-fns", description: "Lightweight" },
+          { label: "dayjs", description: "Small API" },
+        ],
+        multiSelect: false,
+      },
+    ],
+  };
+}
+
+Deno.test("parseQuestions", async (t) => {
+  await t.step("正しい入力から質問一覧を取り出せること", () => {
+    const questions = parseQuestions(validInput());
+
+    assertEquals(questions?.length, 1);
+    assertEquals(questions?.[0].question, "Which library should we use?");
+    assertEquals(questions?.[0].header, "Library");
+    assertEquals(questions?.[0].options.length, 2);
+    assertEquals(questions?.[0].options[0], {
+      label: "date-fns",
+      description: "Lightweight",
+    });
+    assertEquals(questions?.[0].multiSelect, false);
+  });
+
+  await t.step("multiSelect 欠落は false 扱いになること", () => {
+    const input = validInput();
+    const q = (input.questions as Record<string, unknown>[])[0];
+    delete q.multiSelect;
+
+    assertEquals(parseQuestions(input)?.[0].multiSelect, false);
+  });
+
+  await t.step("description 欠落は空文字になること", () => {
+    const input = validInput();
+    const q = (input.questions as Record<string, unknown>[])[0];
+    q.options = [{ label: "a" }, { label: "b" }];
+
+    assertEquals(parseQuestions(input)?.[0].options[0].description, "");
+  });
+
+  await t.step("questions が配列でなければ undefined を返すこと", () => {
+    assertEquals(parseQuestions({}), undefined);
+    assertEquals(parseQuestions({ questions: "invalid" }), undefined);
+  });
+
+  await t.step("質問が 0 件なら undefined を返すこと", () => {
+    assertEquals(parseQuestions({ questions: [] }), undefined);
+  });
+
+  await t.step("質問が 5 件以上なら undefined を返すこと", () => {
+    const q = (validInput().questions as unknown[])[0];
+    assertEquals(parseQuestions({ questions: [q, q, q, q, q] }), undefined);
+  });
+
+  await t.step(
+    "question / header / options 欠落は undefined を返すこと",
+    () => {
+      const base = (validInput().questions as Record<string, unknown>[])[0];
+
+      for (const key of ["question", "header", "options"]) {
+        const broken = { ...base };
+        delete broken[key];
+        assertEquals(parseQuestions({ questions: [broken] }), undefined);
+      }
+    },
+  );
+
+  await t.step("選択肢が空配列なら undefined を返すこと", () => {
+    const base = (validInput().questions as Record<string, unknown>[])[0];
+    assertEquals(
+      parseQuestions({ questions: [{ ...base, options: [] }] }),
+      undefined,
+    );
+  });
+
+  await t.step("選択肢の label 欠落は undefined を返すこと", () => {
+    const base = (validInput().questions as Record<string, unknown>[])[0];
+    assertEquals(
+      parseQuestions({
+        questions: [{ ...base, options: [{ description: "x" }] }],
+      }),
+      undefined,
+    );
+  });
+});
+
+Deno.test("resolveSelectedLabels", async (t) => {
+  const question: Question = {
+    question: "q",
+    header: "h",
+    options: [
+      { label: "Alpha", description: "" },
+      { label: "Beta", description: "" },
+      { label: "Gamma", description: "" },
+    ],
+    multiSelect: true,
+  };
+
+  await t.step("value (index 文字列) をラベルに解決すること", () => {
+    assertEquals(resolveSelectedLabels(question, ["0", "2"]), {
+      labels: ["Alpha", "Gamma"],
+      hasOther: false,
+    });
+  });
+
+  await t.step("Other の value を hasOther として検出すること", () => {
+    assertEquals(resolveSelectedLabels(question, ["1", OTHER_VALUE]), {
+      labels: ["Beta"],
+      hasOther: true,
+    });
+  });
+
+  await t.step("不明な value は無視すること", () => {
+    assertEquals(resolveSelectedLabels(question, ["99", "abc"]), {
+      labels: [],
+      hasOther: false,
+    });
+  });
+});
+
+Deno.test("formatAnswer", async (t) => {
+  await t.step("単一選択はラベルそのままであること", () => {
+    assertEquals(formatAnswer(["Alpha"]), "Alpha");
+  });
+
+  await t.step("複数選択は ', ' 連結であること", () => {
+    assertEquals(formatAnswer(["Alpha", "Beta"]), "Alpha, Beta");
+  });
+});
+
+Deno.test("truncate", async (t) => {
+  await t.step("上限以下はそのまま返すこと", () => {
+    assertEquals(truncate("abc", 3), "abc");
+  });
+
+  await t.step("上限超過は省略記号付きで切り詰めること", () => {
+    assertEquals(truncate("abcdef", 4), "abc…");
+    assertEquals(truncate("abcdef", 4).length, 4);
+  });
+});

--- a/approval/question.ts
+++ b/approval/question.ts
@@ -1,0 +1,536 @@
+/**
+ * Discord select menu による AskUserQuestion 回答マネージャー。
+ *
+ * Agent SDK の AskUserQuestion ツールは `canUseTool` コールバックに
+ * `toolName === "AskUserQuestion"` として流れてくる。質問 (1〜4 件) を
+ * Discord の StringSelectMenu で提示し、ユーザーの回答を収集して
+ * `updatedInput.answers` (質問文 → 選択ラベル) として返すための部品。
+ *
+ * 各質問の選択肢には自動で「Other (自由入力)」を追加し、選択時は
+ * Modal (テキスト入力) で自由記述を受け付ける。
+ */
+
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  type ButtonInteraction,
+  ButtonStyle,
+  type Client,
+  type GuildTextBasedChannel,
+  LabelBuilder,
+  MessageFlags,
+  ModalBuilder,
+  type ModalMessageModalSubmitInteraction,
+  type ModalSubmitInteraction,
+  StringSelectMenuBuilder,
+  type StringSelectMenuInteraction,
+  TextInputBuilder,
+  TextInputStyle,
+} from "discord.js";
+import { createLogger } from "../logger.ts";
+import { getErrorMessage } from "../errors.ts";
+
+const log = createLogger("question");
+
+/**
+ * 回答タイムアウト（ミリ秒）。承認 (ApprovalManager) と同じ 5 分。
+ */
+const ANSWER_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * 「Other (自由入力)」選択肢の select value。
+ */
+export const OTHER_VALUE = "__other__";
+
+/**
+ * AskUserQuestion の 1 質問。SDK の `AskUserQuestionInput` の 1 要素に対応する。
+ *
+ * SDK 側の型は 1〜4 件の固定長タプルの合併で扱いづらいため、実行時検証
+ * ({@link parseQuestions}) を単一ソースにローカルで定義する。
+ */
+export interface Question {
+  question: string;
+  header: string;
+  options: QuestionOption[];
+  multiSelect: boolean;
+}
+
+/**
+ * 質問の選択肢。
+ */
+export interface QuestionOption {
+  label: string;
+  description: string;
+}
+
+/**
+ * 回答収集の結果。
+ *
+ * `answered` の `answers` は質問文 → 回答文字列 (multiSelect は ", " 連結)。
+ * SDK の `updatedInput.answers` にそのまま載せる形。
+ */
+export type QuestionResult =
+  | { kind: "answered"; answers: Record<string, string> }
+  | { kind: "denied"; reason: string };
+
+/**
+ * Discord の component 数上限に由来する質問数の上限。
+ *
+ * 1 メッセージの action row は最大 5。質問ごとに select 1 行 + Cancel
+ * ボタン 1 行で、質問は最大 4 件 (SDK スキーマの上限とも一致する)。
+ */
+const MAX_QUESTIONS = 4;
+
+/**
+ * 1 つの select に載せられる選択肢の上限 (Discord 上限 25 - Other 1 件)。
+ */
+const MAX_OPTIONS = 24;
+
+/**
+ * unknown 値がプレーンなオブジェクト (Record) であるか判定する type guard。
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+/**
+ * `canUseTool` が受け取った AskUserQuestion の入力から質問一覧を取り出す。
+ *
+ * 構造が不正な場合 (questions が配列でない、件数が 0 または 5 以上、
+ * 選択肢が欠落している等) は `undefined` を返す。`multiSelect` の欠落は
+ * `false` 扱いにする。
+ */
+export function parseQuestions(
+  input: Record<string, unknown>,
+): Question[] | undefined {
+  const questions = input.questions;
+  if (!Array.isArray(questions)) {
+    return undefined;
+  }
+  if (questions.length < 1 || questions.length > MAX_QUESTIONS) {
+    return undefined;
+  }
+
+  const parsed: Question[] = [];
+  for (const record of questions) {
+    if (!isRecord(record)) {
+      return undefined;
+    }
+    if (
+      typeof record.question !== "string" ||
+      typeof record.header !== "string" ||
+      !Array.isArray(record.options) ||
+      record.options.length < 1
+    ) {
+      return undefined;
+    }
+    const options: QuestionOption[] = [];
+    for (const opt of record.options.slice(0, MAX_OPTIONS)) {
+      if (!isRecord(opt)) {
+        return undefined;
+      }
+      if (typeof opt.label !== "string" || opt.label.length === 0) {
+        return undefined;
+      }
+      options.push({
+        label: opt.label,
+        description: typeof opt.description === "string" ? opt.description : "",
+      });
+    }
+    parsed.push({
+      question: record.question,
+      header: record.header,
+      options,
+      multiSelect: record.multiSelect === true,
+    });
+  }
+  return parsed;
+}
+
+/**
+ * select の values (選択肢 index の文字列 / {@link OTHER_VALUE}) を
+ * 選択肢ラベルに解決する。
+ *
+ * 不明な value は無視する。`hasOther` は Other が含まれていたかを示す。
+ */
+export function resolveSelectedLabels(
+  question: Question,
+  values: string[],
+): { labels: string[]; hasOther: boolean } {
+  const labels: string[] = [];
+  let hasOther = false;
+  for (const value of values) {
+    if (value === OTHER_VALUE) {
+      hasOther = true;
+      continue;
+    }
+    const index = Number(value);
+    const option = question.options[index];
+    if (option) {
+      labels.push(option.label);
+    }
+  }
+  return { labels, hasOther };
+}
+
+/**
+ * 選択ラベル群を SDK の answers 値 (1 文字列) に組み立てる。
+ * multiSelect の回答は ", " 連結 (SDK の AskUserQuestionOutput の仕様に合わせる)。
+ */
+export function formatAnswer(labels: string[]): string {
+  return labels.join(", ");
+}
+
+/**
+ * Discord の文字数上限に合わせて文字列を切り詰める。
+ */
+export function truncate(text: string, max: number): string {
+  if (text.length <= max) {
+    return text;
+  }
+  return text.slice(0, max - 1) + "…";
+}
+
+/**
+ * 収集中の質問セットの状態。
+ */
+interface PendingQuestions {
+  questions: Question[];
+  /** 質問 index → 確定した回答文字列。 */
+  answers: Map<number, string>;
+  /** Other 選択時、Modal 入力待ちの間に併選択されたラベルを保持する。 */
+  pendingOther: Map<number, string[]>;
+  resolve: (result: QuestionResult) => void;
+  timeout: ReturnType<typeof setTimeout>;
+}
+
+/**
+ * AskUserQuestion 回答マネージャー。
+ *
+ * 質問メッセージの送信、select / Modal / Cancel ボタンのインタラクション
+ * 処理、回答の収集を担う。channel の解決 (fallback 含む) は呼び出し側
+ * (ApprovalManager) の責務とし、ここでは受け取った channelId を使うだけ。
+ */
+export class QuestionManager {
+  private pending = new Map<string, PendingQuestions>();
+
+  constructor(private client: Client) {}
+
+  /**
+   * 質問を Discord に送信し、全質問への回答が揃うまで待つ。
+   *
+   * Cancel ボタン押下・タイムアウト・チャンネル解決失敗は `denied` を返す。
+   */
+  async requestAnswers(
+    questions: Question[],
+    channelId?: string,
+  ): Promise<QuestionResult> {
+    if (!channelId) {
+      log.warn("no channel set for questions, denying");
+      return { kind: "denied", reason: "No channel to ask the user" };
+    }
+
+    const channel = await this.client.channels.fetch(channelId);
+    if (!channel || !channel.isTextBased()) {
+      log.warn("question channel not found:", channelId);
+      return { kind: "denied", reason: "Channel not found" };
+    }
+
+    const requestId = crypto.randomUUID().slice(0, 8);
+
+    const contentLines = [
+      "**Claude からの質問**",
+      ...questions.map((q, i) => `**${i + 1}. ${q.header}** — ${q.question}`),
+    ];
+    const content = truncate(contentLines.join("\n"), 2000);
+
+    const message = await (channel as GuildTextBasedChannel).send({
+      content,
+      components: this.buildComponents(requestId, questions, new Map()),
+    });
+
+    log.info(
+      "questions requested:",
+      requestId,
+      `${questions.length} question(s)`,
+    );
+
+    return new Promise<QuestionResult>((resolve) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(requestId);
+        log.warn("questions timed out:", requestId);
+        message.edit({
+          content: truncate(message.content + "\n**→ Timed out**", 2000),
+          components: [],
+        }).catch((error: unknown) => {
+          log.warn("failed to edit timed out message:", getErrorMessage(error));
+        });
+        resolve({ kind: "denied", reason: "Timed out" });
+      }, ANSWER_TIMEOUT_MS);
+
+      this.pending.set(requestId, {
+        questions,
+        answers: new Map(),
+        pendingOther: new Map(),
+        resolve,
+        timeout,
+      });
+    });
+  }
+
+  /**
+   * select メニューのインタラクションを処理する。
+   *
+   * 対象外の customId なら `false` を返す (他のハンドラへ回す)。
+   */
+  async handleSelect(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<boolean> {
+    const parts = interaction.customId.split(":");
+    if (parts[0] !== "question") {
+      return false;
+    }
+    const requestId = parts[1];
+    const index = Number(parts[2]);
+
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      await this.replyExpired(interaction);
+      return true;
+    }
+    const question = pending.questions[index];
+    if (!question) {
+      return true;
+    }
+
+    const { labels, hasOther } = resolveSelectedLabels(
+      question,
+      interaction.values,
+    );
+
+    if (hasOther) {
+      // Modal を開いて自由記述を待つ。回答の確定は handleModal で行う。
+      pending.pendingOther.set(index, labels);
+      await interaction.showModal(
+        this.buildOtherModal(requestId, index, question),
+      );
+      return true;
+    }
+
+    pending.answers.set(index, formatAnswer(labels));
+    await this.applyProgress(interaction, requestId, pending);
+    return true;
+  }
+
+  /**
+   * Other (自由入力) Modal の送信を処理する。
+   *
+   * 対象外の customId なら `false` を返す。
+   */
+  async handleModal(interaction: ModalSubmitInteraction): Promise<boolean> {
+    const parts = interaction.customId.split(":");
+    if (parts[0] !== "question-other") {
+      return false;
+    }
+    const requestId = parts[1];
+    const index = Number(parts[2]);
+
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      await this.replyExpired(interaction);
+      return true;
+    }
+    if (!pending.questions[index]) {
+      return true;
+    }
+
+    const text = interaction.fields.getTextInputValue("text").trim();
+    const labels = pending.pendingOther.get(index) ?? [];
+    pending.pendingOther.delete(index);
+    const combined = text ? [...labels, text] : labels;
+    pending.answers.set(
+      index,
+      formatAnswer(combined.length > 0 ? combined : ["(no answer)"]),
+    );
+
+    if (interaction.isFromMessage()) {
+      await this.applyProgress(interaction, requestId, pending);
+    }
+    return true;
+  }
+
+  /**
+   * Cancel ボタンのインタラクションを処理する。
+   *
+   * 対象外の customId なら `false` を返す。
+   */
+  async handleButton(interaction: ButtonInteraction): Promise<boolean> {
+    const parts = interaction.customId.split(":");
+    if (parts[0] !== "question-cancel") {
+      return false;
+    }
+    const requestId = parts[1];
+
+    const pending = this.pending.get(requestId);
+    if (!pending) {
+      await this.replyExpired(interaction);
+      return true;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(requestId);
+    pending.resolve({ kind: "denied", reason: "Cancelled by user" });
+
+    await interaction.update({
+      content: interaction.message.content + "\n**→ Cancelled**",
+      components: [],
+    });
+
+    log.info("questions cancelled:", requestId);
+    return true;
+  }
+
+  /**
+   * 回答の進捗をメッセージへ反映し、全問回答済みなら resolve する。
+   */
+  private async applyProgress(
+    interaction:
+      | StringSelectMenuInteraction
+      | ModalMessageModalSubmitInteraction,
+    requestId: string,
+    pending: PendingQuestions,
+  ): Promise<void> {
+    if (pending.answers.size < pending.questions.length) {
+      await interaction.update({
+        components: this.buildComponents(
+          requestId,
+          pending.questions,
+          pending.answers,
+        ),
+      });
+      return;
+    }
+
+    clearTimeout(pending.timeout);
+    this.pending.delete(requestId);
+
+    const answers: Record<string, string> = {};
+    pending.questions.forEach((q, i) => {
+      answers[q.question] = pending.answers.get(i) ?? "";
+    });
+    pending.resolve({ kind: "answered", answers });
+
+    const summary = pending.questions
+      .map((q, i) => `**${q.header}**: ${pending.answers.get(i) ?? ""}`)
+      .join("\n");
+    await interaction.update({
+      content: truncate(
+        interaction.message.content + "\n**→ 回答済み**\n" + summary,
+        2000,
+      ),
+      components: [],
+    });
+
+    log.info("questions answered:", requestId);
+  }
+
+  /**
+   * 質問セットから action row 群 (select × 質問数 + Cancel ボタン) を構築する。
+   *
+   * 回答済みの質問の select は disabled にし、placeholder に回答を表示する。
+   */
+  private buildComponents(
+    requestId: string,
+    questions: Question[],
+    answers: Map<number, string>,
+  ): ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>[] {
+    const rows: ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>[] =
+      questions.map((q, i) => {
+        const answered = answers.get(i);
+        const select = new StringSelectMenuBuilder()
+          .setCustomId(`question:${requestId}:${i}`)
+          .setPlaceholder(
+            truncate(
+              answered !== undefined
+                ? `${i + 1}. ${answered}`
+                : `${i + 1}. ${q.question}`,
+              150,
+            ),
+          )
+          .setDisabled(answered !== undefined)
+          .setMinValues(1)
+          .setMaxValues(q.multiSelect ? q.options.length + 1 : 1)
+          .addOptions(
+            ...q.options.map((o, j) => ({
+              label: truncate(o.label, 100),
+              value: String(j),
+              ...(o.description
+                ? { description: truncate(o.description, 100) }
+                : {}),
+            })),
+            {
+              label: "Other (自由入力)",
+              value: OTHER_VALUE,
+              description: "選択肢に無い回答をテキストで入力する",
+            },
+          );
+        return new ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>()
+          .addComponents(select);
+      });
+
+    rows.push(
+      new ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>()
+        .addComponents(
+          new ButtonBuilder()
+            .setCustomId(`question-cancel:${requestId}`)
+            .setLabel("Cancel")
+            .setStyle(ButtonStyle.Danger),
+        ),
+    );
+
+    return rows;
+  }
+
+  /**
+   * Other (自由入力) 用の Modal を構築する。
+   */
+  private buildOtherModal(
+    requestId: string,
+    index: number,
+    question: Question,
+  ): ModalBuilder {
+    return new ModalBuilder()
+      .setCustomId(`question-other:${requestId}:${index}`)
+      .setTitle(truncate(question.header, 45))
+      .addLabelComponents(
+        new LabelBuilder()
+          .setLabel(truncate(question.question, 45))
+          .setTextInputComponent(
+            new TextInputBuilder()
+              .setCustomId("text")
+              .setStyle(TextInputStyle.Paragraph)
+              .setRequired(true)
+              .setMaxLength(1000),
+          ),
+      );
+  }
+
+  /**
+   * 期限切れ・処理済みのインタラクションに ephemeral で応答する。
+   */
+  private async replyExpired(
+    interaction:
+      | StringSelectMenuInteraction
+      | ModalSubmitInteraction
+      | ButtonInteraction,
+  ): Promise<void> {
+    try {
+      await interaction.reply({
+        content: "この質問は期限切れか、既に処理済みです。",
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (error: unknown) {
+      log.warn("failed to reply expired:", getErrorMessage(error));
+    }
+  }
+}

--- a/bot/mod.ts
+++ b/bot/mod.ts
@@ -255,7 +255,7 @@ export class DiscordBot {
    * スラッシュコマンドのハンドラ。
    */
   private async onInteraction(interaction: Interaction): Promise<void> {
-    // ボタンインタラクション（承認/拒否）
+    // ボタンインタラクション（承認/拒否、質問の Cancel）
     if (interaction.isButton()) {
       try {
         await this.approvalManager.handleButton(interaction);
@@ -265,6 +265,40 @@ export class DiscordBot {
         if (!interaction.replied && !interaction.deferred) {
           await interaction.reply({
             content: "承認処理中にエラーが発生しました。",
+            flags: MessageFlags.Ephemeral,
+          }).catch(() => {});
+        }
+      }
+      return;
+    }
+
+    // select メニュー（AskUserQuestion の回答）
+    if (interaction.isStringSelectMenu()) {
+      try {
+        await this.approvalManager.handleSelect(interaction);
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        log.error("select interaction error:", msg);
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({
+            content: "回答処理中にエラーが発生しました。",
+            flags: MessageFlags.Ephemeral,
+          }).catch(() => {});
+        }
+      }
+      return;
+    }
+
+    // Modal 送信（AskUserQuestion の Other 自由入力）
+    if (interaction.isModalSubmit()) {
+      try {
+        await this.approvalManager.handleModal(interaction);
+      } catch (error: unknown) {
+        const msg = getErrorMessage(error);
+        log.error("modal interaction error:", msg);
+        if (!interaction.replied && !interaction.deferred) {
+          await interaction.reply({
+            content: "回答処理中にエラーが発生しました。",
             flags: MessageFlags.Ephemeral,
           }).catch(() => {});
         }


### PR DESCRIPTION
## 概要

Agent SDK の `AskUserQuestion` ツールに対応する。従来は `canUseTool` 経由で承認フロー (Allow/Deny ボタン) に回るだけで回答を返す手段が無く、質問として機能しなかった。

## 変更内容

- **`approval/question.ts` 新設**: `QuestionManager` が質問 (1〜4 件) を Discord の StringSelectMenu で提示して回答を収集する。全問回答で resolve し、`updatedInput.answers` (質問文 → 選択ラベル) に載せて `behavior: "allow"` で返す。
- **Other (自由入力) 対応**: 各質問の選択肢に「Other (自由入力)」を追加。選択時は Modal (テキスト入力) で自由記述を受け付ける。`multiSelect` の回答は `", "` 連結 (SDK の `AskUserQuestionOutput` の仕様に合わせる)。
- **Cancel / タイムアウト**: Cancel ボタン・タイムアウト (5 分、承認と同じ)・チャンネル解決失敗は `deny` で返し、モデルは回答なしで続行する。
- **`createCanUseTool()` に分岐追加**: `toolName === "AskUserQuestion"` は承認フローを通さず回答収集へ。`ApprovalManager` が `QuestionManager` を内包するため、chat / voice / cron の 3 経路すべてに変更なしで効く。
- **`bot/mod.ts`**: select menu / Modal のインタラクションルーティングを追加。
- **CLAUDE.md**: ファイル構成・ツール権限の節を更新。

## 実装の根拠

- SDK 0.3.199 の `sdk-tools.d.ts` の `AskUserQuestionInput` に optional な `answers` フィールドがあり、「User answers collected by the permission component」と記載。
- 公式ドキュメント [Handle approvals and user input](https://code.claude.com/docs/en/agent-sdk/user-input) の Response format に従い、`{ behavior: "allow", updatedInput: { questions, answers } }` を返す。

## 注意事項

`.claude/settings.json` の `permissions.allow` に `AskUserQuestion` を入れると、SDK が `canUseTool` を呼ばずに素通しして回答が空のまま解決される。このツールは allow list に入れないこと (CLAUDE.md に記載済み)。

## テスト

- `deno task check` / `deno task lint`: pass
- `deno task test`: 48 passed (317 steps), 0 failed
- 追加テスト: `parseQuestions` / `resolveSelectedLabels` / `formatAnswer` / `truncate` の単体テスト、`createCanUseTool` の AskUserQuestion 分岐 (allow / deny / 不正入力)
- 実機での Discord インタラクション操作 (select / Modal) は未検証。本番 bot トークンでの二重ログインを避けるため、デプロイ後の動作確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)