### PR TITLE
chore: .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,17 @@
+# git worktree 作成時に git-worktree-include がメイン worktree からコピーする
+# ローカル資産の一覧 (gitignore 構文。マッチしたファイルが新しい worktree へ複製される)。
+#
+# data/ 配下の実行時データは本番 (ceres:/opt/services/loms-claw/data) から
+# メイン worktree の data/ へ同期したものを正とし、各 worktree はそこから複製する。
+
+# docker compose が host 側で読む env (存在する場合のみ)
+.env
+
+# アプリ設定 (ローカル実行用に調整した config)
+data/config.json
+
+# Claude の設定・認証情報 (CLAUDE_CONFIG_DIR が指す先)
+data/home/
+
+# エージェントワークスペース (.claude/, システムプロンプト, cron 等)
+data/workspace/


### PR DESCRIPTION
## 概要

`git-worktree-include` で worktree 作成時にローカル実行時データをメインの worktree から複製できるようにする。

## 内容

`.worktreeinclude` (gitignore 構文) に以下を記載:

- `.env` — docker compose が host 側で読む env (存在する場合のみ)
- `data/config.json` — アプリ設定 (ローカル実行用に調整した config)
- `data/home/` — Claude の設定・認証情報 (`CLAUDE_CONFIG_DIR` が指す先)
- `data/workspace/` — エージェントワークスペース (.claude/, システムプロンプト, cron 等)

## 運用

data/ 配下の実行時データは本番 (`ceres:/opt/services/loms-claw/data`) からメイン worktree の `data/` へ同期したものを正とし、各 worktree はそこから複製する。

`data/workspace/` は一部が git 追跡下にあるため、メイン側が本番同期で HEAD と差分を持つ場合、複製先の worktree にもその差分が現れる (テスト時の本番再現性を優先)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)